### PR TITLE
check http status for clone URL

### DIFF
--- a/src/gitleaks/handler.go
+++ b/src/gitleaks/handler.go
@@ -100,9 +100,9 @@ func (s *sqsHandler) HandleMessage(msg *sqs.Message) error {
 			appLogger.Errorf("Failed to put findngs: gitleaks_id=%d, err=%+v", message.GitleaksID, err)
 			return s.updateScanStatusError(ctx, scanStatus, err.Error())
 		}
-		if err := s.updateScanStatusSuccess(ctx, scanStatus); err != nil {
-			return err
-		}
+	}
+	if err := s.updateScanStatusSuccess(ctx, scanStatus); err != nil {
+		return err
 	}
 	return s.analyzeAlert(ctx, message.ProjectID)
 }


### PR DESCRIPTION
GitHubのCloneURL がHTTP 200 OK以外の場合、 GitLeaksがエラーを返さずに落ちてしまうことが分かったので、GitLeaksのスキャン前にHTTPチェックを実施。
200以外が返ってきたらスキャンをスキップさせる対応を入れます。