### PR TITLE
fix: user repository

### DIFF
--- a/src/gitleaks/github.go
+++ b/src/gitleaks/github.go
@@ -214,7 +214,6 @@ func (g *githubClient) listRepositoryForUserWithOption(ctx context.Context, base
 		}
 		appLogger.Infof("Success GitHub API for user repos, baseURL: %s,login:%s, option:%+v, repo_count: %d, response:%+v", client.BaseURL, login, opt, len(repos), resp)
 		for _, r := range repos {
-			appLogger.Debugf("owner.login=%s, login=%s, visi=%s", *r.Owner.Login, login, *r.Visibility)
 			if *r.Owner.Login == login {
 				allRepo = append(allRepo, r)
 			}


### PR DESCRIPTION
userリポジトリを取得するAPIエンドポイントがpublicリポジトリのみしかとれないものになっていました。
こちらは、以下のAPIエンドポイントに変更して、privateリポジトリを取得できるようにします。
https://docs.github.com/ja/rest/repos/repos#list-repositories-for-the-authenticated-user

また、Org側の実装方針にあわせて、visibilityは一旦allで取得し、取得後にフィルタする方針にします。（APIの実行回数は減らせる利点があるのと実装方式のズレをなくす意図です）

close https://github.com/ca-risken/internal-community/issues/263