### PR TITLE
Integrate log and trace in code

### DIFF
--- a/src/code/client.go
+++ b/src/code/client.go
@@ -14,7 +14,7 @@ func newProjectClient(coreSvcAddr string) project.ProjectServiceClient {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, coreSvcAddr)
 	if err != nil {
-		appLogger.Fatalf("Faild to get GRPC connection: err=%+v", err)
+		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
 	}
 	return project.NewProjectServiceClient(conn)
 }

--- a/src/code/go.mod
+++ b/src/code/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/ca-risken/code/pkg/common v0.0.0-20210917082353-3ada53fdb98c
 	github.com/ca-risken/code/proto/code v0.0.0-20210917082353-3ada53fdb98c
 	github.com/ca-risken/common/pkg/database v0.0.0-20220421051518-d57cbf184097
-	github.com/ca-risken/common/pkg/logging v0.0.0-20220113015330-0e8462d52b5b
+	github.com/ca-risken/common/pkg/logging v0.0.0-20220518032134-ad443b601efd
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220304031727-c94e2c463b27
-	github.com/ca-risken/common/pkg/rpc v0.0.0-20220113015330-0e8462d52b5b
+	github.com/ca-risken/common/pkg/rpc v0.0.0-20220518032134-ad443b601efd
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20220421051518-d57cbf184097
 	github.com/ca-risken/core/proto/project v0.0.0-20220120020932-292d4285ee31
 	github.com/gassara-kys/envconfig v1.4.4
@@ -53,7 +53,7 @@ require (
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/tinylib/msgp v1.1.2 // indirect
 	golang.org/x/net v0.0.0-20211020060615-d418f374d309 // indirect
-	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
+	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/src/code/go.sum
+++ b/src/code/go.sum
@@ -108,10 +108,14 @@ github.com/ca-risken/common/pkg/database v0.0.0-20220421051518-d57cbf184097/go.m
 github.com/ca-risken/common/pkg/logging v0.0.0-20220113014249-f285e209578f/go.mod h1:dmZZ5/wkGbsmAMbhuC7YK6uJOMAlS4OndoM0DQyPhi8=
 github.com/ca-risken/common/pkg/logging v0.0.0-20220113015330-0e8462d52b5b h1:3Mn6kwDX2mISoCGdF/eYcfpGS0m6d17Z8t8HSl6s1bQ=
 github.com/ca-risken/common/pkg/logging v0.0.0-20220113015330-0e8462d52b5b/go.mod h1:dmZZ5/wkGbsmAMbhuC7YK6uJOMAlS4OndoM0DQyPhi8=
+github.com/ca-risken/common/pkg/logging v0.0.0-20220518032134-ad443b601efd h1:YXyIsRQNxpjNT3QaqYSU/RW7nA8HWh66EIE69yc0w/I=
+github.com/ca-risken/common/pkg/logging v0.0.0-20220518032134-ad443b601efd/go.mod h1:iqLbvDuf708TWjF8RO5qw6Nx1e3R0/UEHZ8tE/VEPjA=
 github.com/ca-risken/common/pkg/profiler v0.0.0-20220304031727-c94e2c463b27 h1:NV95obXJwovUBvxWPW5boJcMAwkUIrsqhH3uwhTfTNY=
 github.com/ca-risken/common/pkg/profiler v0.0.0-20220304031727-c94e2c463b27/go.mod h1:xldq3VZ7qomkI5vfpw8Y9qCVEFl8BrSvDr+sxbz32H4=
 github.com/ca-risken/common/pkg/rpc v0.0.0-20220113015330-0e8462d52b5b h1:Bku8qY0JoN4u+OgnFF+t5rzdgi7zp3e1vWL088g+cnQ=
 github.com/ca-risken/common/pkg/rpc v0.0.0-20220113015330-0e8462d52b5b/go.mod h1:A5WmKMV58G2v1s/oNXIzFsd9SiS8YxkkEWT3U6+yPd0=
+github.com/ca-risken/common/pkg/rpc v0.0.0-20220518032134-ad443b601efd h1:rrkuvylG4Etubw0miHpNnWje4VR5ZPUGR8FPmJWNwck=
+github.com/ca-risken/common/pkg/rpc v0.0.0-20220518032134-ad443b601efd/go.mod h1:fnvFF8ESVirs5LV36leyFKf3FbuqjLDhJnipGJgDZtA=
 github.com/ca-risken/common/pkg/tracer v0.0.0-20220421051518-d57cbf184097 h1:kz1mALLbChWS0inQct+rQUpTgCEM5+XL5bzIjmMguF8=
 github.com/ca-risken/common/pkg/tracer v0.0.0-20220421051518-d57cbf184097/go.mod h1:PIXjETIPseBEB/OXp5Rxn8FFuRwfQjFZe1VN+0Skh2E=
 github.com/ca-risken/core/proto/project v0.0.0-20220120020932-292d4285ee31 h1:rLGNhjEn6DlPvvhjPHG6CUIFl0mSrPChocX5UjSW6Bw=
@@ -979,6 +983,8 @@ golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220111092808-5a964db01320/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 h1:nhht2DYV/Sn3qOayu8lM+cU1ii9sTLUeBQwQQfUHtrs=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/src/code/main.go
+++ b/src/code/main.go
@@ -78,8 +78,8 @@ func main() {
 	server := grpc.NewServer(
 		grpc.UnaryInterceptor(
 			grpcmiddleware.ChainUnaryServer(
-				mimosarpc.LoggingUnaryServerInterceptor(appLogger),
-				grpctrace.UnaryServerInterceptor())))
+				grpctrace.UnaryServerInterceptor(),
+				mimosarpc.LoggingUnaryServerInterceptor(appLogger))))
 	codeServer := newCodeService(ctx, conf.CoreSvcAddr)
 	code.RegisterCodeServiceServer(server, codeServer)
 

--- a/src/code/repository.go
+++ b/src/code/repository.go
@@ -33,10 +33,10 @@ type codeRepository struct {
 	SlaveDB  *gorm.DB
 }
 
-func newCodeRepository() codeRepoInterface {
+func newCodeRepository(ctx context.Context) codeRepoInterface {
 	repo := codeRepository{}
-	repo.MasterDB = initDB(true)
-	repo.SlaveDB = initDB(false)
+	repo.MasterDB = initDB(ctx, true)
+	repo.SlaveDB = initDB(ctx, false)
 	return &repo
 }
 
@@ -54,10 +54,10 @@ type dbConfig struct {
 	MaxConnection int    `split_words:"true" default:"10"`
 }
 
-func initDB(isMaster bool) *gorm.DB {
+func initDB(ctx context.Context, isMaster bool) *gorm.DB {
 	conf := &dbConfig{}
 	if err := envconfig.Process("DB", conf); err != nil {
-		appLogger.Fatalf("Failed to load DB config. err: %+v", err)
+		appLogger.Fatalf(ctx, "Failed to load DB config. err: %+v", err)
 	}
 
 	var user, pass, host string
@@ -75,10 +75,10 @@ func initDB(isMaster bool) *gorm.DB {
 		user, pass, host, conf.Port, conf.Schema)
 	db, err := mimosasql.Open(dsn, conf.LogMode, conf.MaxConnection)
 	if err != nil {
-		appLogger.Fatalf("Failed to open DB. isMaster: %t, err: %+v", isMaster, err)
+		appLogger.Fatalf(ctx, "Failed to open DB. isMaster: %t, err: %+v", isMaster, err)
 		return nil
 	}
-	appLogger.Infof("Connected to Database. isMaster: %t", isMaster)
+	appLogger.Infof(ctx, "Connected to Database. isMaster: %t", isMaster)
 	return db
 }
 

--- a/src/code/service_test.go
+++ b/src/code/service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ca-risken/code/pkg/common"
 	"github.com/ca-risken/code/proto/code"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"gorm.io/gorm"
 )
@@ -202,9 +203,7 @@ func TestPutGitleaks(t *testing.T) {
 	now := time.Now()
 	key := []byte("1234567890123456")
 	block, err := aes.NewCipher(key)
-	if err != nil {
-		appLogger.Fatal(err.Error())
-	}
+	assert.NoError(t, err)
 	mockDB := mockCodeRepository{}
 	svc := codeService{
 		repository:  &mockDB,

--- a/src/code/sqs.go
+++ b/src/code/sqs.go
@@ -30,17 +30,17 @@ type sqsClient struct {
 	gitleaksFullScanQueueURL string
 }
 
-func newSQSClient() *sqsClient {
+func newSQSClient(ctx context.Context) *sqsClient {
 	var conf sqsConfig
 	err := envconfig.Process("", &conf)
 	if err != nil {
-		appLogger.Fatal(err.Error())
+		appLogger.Fatal(ctx, err.Error())
 	}
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	})
 	if err != nil {
-		appLogger.Fatalf("Failed to create a new session, %v", err)
+		appLogger.Fatalf(ctx, "Failed to create a new session, %v", err)
 	}
 	session := sqs.New(sess, &aws.Config{
 		Region:   &conf.AWSRegion,


### PR DESCRIPTION
codeサービスのみログとトレースの統合を対応しました。
アクセスログに同様の処理を行うためインタセプターの順序を入れ替えています。

worker系のサービスはaws-sdk-goのバージョンアップが必要になるため、別のPRに切り出す予定です。