### PR TITLE
fix typo dependency-base buildspec-manifest

### DIFF
--- a/codebuild/dependency-base-image/buildspec-manifest.yml
+++ b/codebuild/dependency-base-image/buildspec-manifest.yml
@@ -15,27 +15,27 @@ phases:
       - BUILD_OPT="--no-cache --pull"
 
       - echo Logging in to Amazon ECR...
-      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${REGISTORY}
+      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${REGISTRY}
   build:
     commands:
       - echo Build dependency base image manifest started on `date`
       - TAG=${DEPENDENCY_BASE_VERSION}
       # version tag
-      - docker manifest create ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:${TAG} ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_amd64 ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_arm64
-      - docker manifest annotate --arch amd64 ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:${TAG} ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_amd64
-      - docker manifest annotate --arch arm64 ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:${TAG} ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_arm64
+      - docker manifest create ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG} ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_amd64 ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_arm64
+      - docker manifest annotate --arch amd64 ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG} ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_amd64
+      - docker manifest annotate --arch arm64 ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG} ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_arm64
       # latest
-      - docker manifest create ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:latest ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_amd64 ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_arm64
-      - docker manifest annotate --arch amd64 ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:latest ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_amd64
-      - docker manifest annotate --arch arm64 ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:latest ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_arm64
+      - docker manifest create ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:latest ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_amd64 ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_arm64
+      - docker manifest annotate --arch amd64 ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:latest ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_amd64
+      - docker manifest annotate --arch arm64 ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:latest ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}_linux_arm64
 
   post_build:
     commands:
       - echo Build completed on `date`
       - echo Pushing the Docker manifest...
       # push manifests
-      - docker manifest push ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:${TAG}
-      - docker manifest push ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:latest
+      - docker manifest push ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}
+      - docker manifest push ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:latest
       # inspect
-      - docker manifest inspect ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:${TAG}
-      - docker manifest inspect ${REGISTORY}/${IMAGE_DEPENDENCY_BASE}:latest
+      - docker manifest inspect ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:${TAG}
+      - docker manifest inspect ${REGISTRY}/${IMAGE_DEPENDENCY_BASE}:latest


### PR DESCRIPTION
REGISTORY -> REGISTRY
pahses内の編数名とenvのvariableと変数名が異なっていたのを修正します