### PR TITLE
Fix dependency

### DIFF
--- a/src/dependency/finding.go
+++ b/src/dependency/finding.go
@@ -17,7 +17,7 @@ type vulnerabililityIndex struct {
 	vulnID      string
 }
 
-func makeFindings(msg *message.CodeQueueMessage, report *trivytypes.Report) ([]*finding.FindingBatchForUpsert, error) {
+func makeFindings(msg *message.CodeQueueMessage, report *trivytypes.Report, repositoryID int64) ([]*finding.FindingBatchForUpsert, error) {
 	var findings []*finding.FindingBatchForUpsert
 	results := report.Results
 	for _, result := range results {
@@ -60,6 +60,7 @@ func makeFindings(msg *message.CodeQueueMessage, report *trivytypes.Report) ([]*
 					{Tag: tagDependency},
 					// ex) gomod,pip
 					{Tag: result.Type},
+					{Tag: fmt.Sprintf("repository_id:%v", repositoryID)},
 				},
 			})
 		}

--- a/src/dependency/finding_test.go
+++ b/src/dependency/finding_test.go
@@ -12,11 +12,12 @@ import (
 
 func TestMakeFinding(t *testing.T) {
 	cases := []struct {
-		name    string
-		msg     *message.CodeQueueMessage
-		report  *types.Report
-		want    []*finding.FindingBatchForUpsert
-		wantErr bool
+		name         string
+		msg          *message.CodeQueueMessage
+		report       *types.Report
+		repositoryID int64
+		want         []*finding.FindingBatchForUpsert
+		wantErr      bool
 	}{
 		{
 			name: "OK",
@@ -42,6 +43,7 @@ func TestMakeFinding(t *testing.T) {
 					},
 				},
 			},
+			repositoryID: 1,
 			want: []*finding.FindingBatchForUpsert{
 				{
 					Finding: &finding.FindingForUpsert{
@@ -55,7 +57,7 @@ func TestMakeFinding(t *testing.T) {
 						Data:             "{\"target\":{\"packageName\":\"pkg\",\"repositoryURL\":\"artifact_name\",\"target\":\"target\"},\"vulnerabilities\":[{\"PkgName\":\"pkg\",\"Layer\":{},\"Severity\":\"HIGH\"}]}",
 					},
 					Recommend: getRecommend("pkg"),
-					Tag:       []*finding.FindingTagForBatch{{Tag: tagCode}, {Tag: tagRepository}, {Tag: tagDependency}, {Tag: "module"}},
+					Tag:       []*finding.FindingTagForBatch{{Tag: tagCode}, {Tag: tagRepository}, {Tag: tagDependency}, {Tag: "module"}, {Tag: "repository_id:1"}},
 				},
 			},
 		},
@@ -89,6 +91,7 @@ func TestMakeFinding(t *testing.T) {
 					},
 				},
 			},
+			repositoryID: 1,
 			want: []*finding.FindingBatchForUpsert{
 				{
 					Finding: &finding.FindingForUpsert{
@@ -102,7 +105,7 @@ func TestMakeFinding(t *testing.T) {
 						Data:             "{\"target\":{\"packageName\":\"pkg\",\"repositoryURL\":\"artifact_name\",\"target\":\"target\"},\"vulnerabilities\":[{\"PkgName\":\"pkg\",\"Layer\":{},\"Severity\":\"LOW\"}]}",
 					},
 					Recommend: getRecommend("pkg"),
-					Tag:       []*finding.FindingTagForBatch{{Tag: tagCode}, {Tag: tagRepository}, {Tag: tagDependency}, {Tag: "module"}},
+					Tag:       []*finding.FindingTagForBatch{{Tag: tagCode}, {Tag: tagRepository}, {Tag: tagDependency}, {Tag: "module"}, {Tag: "repository_id:1"}},
 				},
 				{
 					Finding: &finding.FindingForUpsert{
@@ -116,7 +119,7 @@ func TestMakeFinding(t *testing.T) {
 						Data:             "{\"target\":{\"packageName\":\"pkg2\",\"repositoryURL\":\"artifact_name\",\"target\":\"target\"},\"vulnerabilities\":[{\"PkgName\":\"pkg2\",\"Layer\":{},\"Severity\":\"MEDIUM\"}]}",
 					},
 					Recommend: getRecommend("pkg2"),
-					Tag:       []*finding.FindingTagForBatch{{Tag: tagCode}, {Tag: tagRepository}, {Tag: tagDependency}, {Tag: "module"}},
+					Tag:       []*finding.FindingTagForBatch{{Tag: tagCode}, {Tag: tagRepository}, {Tag: tagDependency}, {Tag: "module"}, {Tag: "repository_id:1"}},
 				},
 			},
 		},
@@ -150,6 +153,7 @@ func TestMakeFinding(t *testing.T) {
 					},
 				},
 			},
+			repositoryID: 1,
 			want: []*finding.FindingBatchForUpsert{
 				{
 					Finding: &finding.FindingForUpsert{
@@ -163,7 +167,7 @@ func TestMakeFinding(t *testing.T) {
 						Data:             "{\"target\":{\"packageName\":\"pkg\",\"repositoryURL\":\"artifact_name\",\"target\":\"target\"},\"vulnerabilities\":[{\"PkgName\":\"pkg\",\"Layer\":{},\"Severity\":\"LOW\"},{\"PkgName\":\"pkg\",\"Layer\":{},\"Severity\":\"MEDIUM\"}]}",
 					},
 					Recommend: getRecommend("pkg"),
-					Tag:       []*finding.FindingTagForBatch{{Tag: tagCode}, {Tag: tagRepository}, {Tag: tagDependency}, {Tag: "module"}},
+					Tag:       []*finding.FindingTagForBatch{{Tag: tagCode}, {Tag: tagRepository}, {Tag: tagDependency}, {Tag: "module"}, {Tag: "repository_id:1"}},
 				},
 			},
 		},
@@ -207,7 +211,7 @@ func TestMakeFinding(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got, err := makeFindings(c.msg, c.report)
+			got, err := makeFindings(c.msg, c.report, c.repositoryID)
 			if c.wantErr && err == nil {
 				t.Fatal("Unexpected no error")
 			}

--- a/src/dependency/handler.go
+++ b/src/dependency/handler.go
@@ -113,7 +113,7 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 		}
 
 		// Scan per repository
-		resultFilePath := fmt.Sprintf("%v_%v_%s_%v.json", msg.ProjectID, msg.GitHubSettingID, *r.Name, time.Now().Unix())
+		resultFilePath := fmt.Sprintf("/tmp/%v_%v_%s_%v.json", msg.ProjectID, msg.GitHubSettingID, *r.Name, time.Now().Unix())
 		result, err := s.dependencyClient.getResult(ctx, *r.CloneURL, gitHubSetting.PersonalAccessToken, resultFilePath)
 		if err != nil {
 			appLogger.Errorf(ctx, "Failed to scan repositories: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)

--- a/src/dependency/handler.go
+++ b/src/dependency/handler.go
@@ -121,12 +121,23 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 			return mimosasqs.WrapNonRetryable(err)
 		}
 
-		findings, err := makeFindings(msg, result)
+		findings, err := makeFindings(msg, result, r.GetID())
 		if err != nil {
 			appLogger.Errorf(ctx, "Failed to make findings: github_setting_id=%d, repository_name=%s, err=%+v", msg.GitHubSettingID, r.GetFullName(), err)
 			s.updateStatusToError(ctx, scanStatus, err)
 			return mimosasqs.WrapNonRetryable(err)
 		}
+
+		if _, err := s.findingClient.ClearScore(ctx, &finding.ClearScoreRequest{
+			DataSource: message.DependencyDataSource,
+			ProjectId:  msg.ProjectID,
+			Tag:        []string{fmt.Sprintf("repository_id:%v", r.GetID())},
+		}); err != nil {
+			appLogger.Errorf(ctx, "Failed to clear finding score. repository: %v, error: %v", r.Name, err)
+			s.updateStatusToError(ctx, scanStatus, err)
+			return mimosasqs.WrapNonRetryable(err)
+		}
+
 		// Put findings
 		if err := s.putFindings(ctx, msg.ProjectID, findings); err != nil {
 			appLogger.Errorf(ctx, "failed to put findings: github_setting_id=%d, repository_name=%s, err=%+v", msg.GitHubSettingID, r.GetFullName(), err)


### PR DESCRIPTION
以下、２点の修正を行います。
#### clearScore処理の追加
一度生成されたFindingが(その問題を修正しても)削除されないため、clearScoreを実施してFinding登録前に既存のもののスコアを下げます。
また、clearScore処理を行う対象をフィルタリングするために`repository_id:{repo_id}`のタグを追加します。
repository_nameをタグを登録したかったのですが、リポジトリ名の最大長が100のためtagの最大長(64)を上回る際に登録できない可能性があるため、repository_idにしました。

#### trivyの実行結果ファイルの格納先変更
non root userでもtrivyを実行できる様に /tmp/ 以下に結果ファイルを格納します。