### PR TITLE
Improve error handling gitleaks

### DIFF
--- a/src/gitleaks/grpc_client.go
+++ b/src/gitleaks/grpc_client.go
@@ -11,31 +11,28 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func newFindingClient(svcAddr string) finding.FindingServiceClient {
-	ctx := context.Background()
+func newFindingClient(ctx context.Context, svcAddr string) (finding.FindingServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, err
 	}
-	return finding.NewFindingServiceClient(conn)
+	return finding.NewFindingServiceClient(conn), nil
 }
 
-func newAlertClient(svcAddr string) alert.AlertServiceClient {
-	ctx := context.Background()
+func newAlertClient(ctx context.Context, svcAddr string) (alert.AlertServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, err
 	}
-	return alert.NewAlertServiceClient(conn)
+	return alert.NewAlertServiceClient(conn), nil
 }
 
-func newCodeClient(svcAddr string) code.CodeServiceClient {
-	ctx := context.Background()
+func newCodeClient(ctx context.Context, svcAddr string) (code.CodeServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, err
 	}
-	return code.NewCodeServiceClient(conn)
+	return code.NewCodeServiceClient(conn), nil
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {

--- a/src/gitleaks/handler.go
+++ b/src/gitleaks/handler.go
@@ -491,7 +491,7 @@ func (s *sqsHandler) putResource(ctx context.Context, projectID uint32, resource
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("failed to put resource: project_id=%d, resource_name=%s", projectID, resourceName)
+		return fmt.Errorf("failed to put resource: project_id=%d, resource_name=%s, err=%w", projectID, resourceName, err)
 	}
 	s.tagResource(ctx, tagCode, resp.Resource.ResourceId, projectID)
 	s.tagResource(ctx, tagRipository, resp.Resource.ResourceId, projectID)

--- a/src/gitleaks/handler.go
+++ b/src/gitleaks/handler.go
@@ -414,7 +414,7 @@ func (s *sqsHandler) listRepositoryEnterprise(ctx context.Context, config *code.
 			config.TargetResource = org.Organization
 			repo, err := s.githubClient.listRepository(ctx, config)
 			if err != nil {
-				// Enterprise配下のOrgがうまく取得できない場合（クローズ済みなど）もあるため、WARNログ吐いて握りつぶす
+				// Enterprise配下のOrgがうまく取得できない場合（クローズ済みなど）もあるため、WARNログ吐いて握りつぶす（スキャンすべきリポジトリが漏れる可能性はあるが、enterpriseのサポートは廃止予定なので対応は行わない）
 				appLogger.Warnf(ctx, "Failed to ListRepository by enterprise, org=%s, err=%+v", org.Organization, err)
 				continue
 			}

--- a/src/gitleaks/handler_test.go
+++ b/src/gitleaks/handler_test.go
@@ -245,4 +245,3 @@ func TestGetRecommend(t *testing.T) {
 		})
 	}
 }
-

--- a/src/gitleaks/main.go
+++ b/src/gitleaks/main.go
@@ -106,11 +106,15 @@ func main() {
 		appLogger.Fatalf(ctx, "Failed to create Finalizer, err=%+v", err)
 	}
 	consumer := newSQSConsumer(ctx, sqsConf)
+	handler, err := newHandler(ctx, &conf)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create Handler, err=%+v", err)
+	}
 	appLogger.Info(ctx, "Start the gitleaks SQS consumer server...")
 	consumer.Start(ctx,
 		mimosasqs.InitializeHandler(
 			mimosasqs.RetryableErrorHandler(
 				mimosasqs.TracingHandler(getFullServiceName(),
 					mimosasqs.StatusLoggingHandler(appLogger,
-						f.FinalizeHandler(newHandler(ctx, &conf)))))))
+						f.FinalizeHandler(handler))))))
 }

--- a/src/gitleaks/main.go
+++ b/src/gitleaks/main.go
@@ -105,7 +105,10 @@ func main() {
 	if err != nil {
 		appLogger.Fatalf(ctx, "Failed to create Finalizer, err=%+v", err)
 	}
-	consumer := newSQSConsumer(ctx, sqsConf)
+	consumer, err := newSQSConsumer(ctx, sqsConf)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create SQS consumer, err=%+v", err)
+	}
 	handler, err := newHandler(ctx, &conf)
 	if err != nil {
 		appLogger.Fatalf(ctx, "Failed to create Handler, err=%+v", err)

--- a/src/gitleaks/sqs.go
+++ b/src/gitleaks/sqs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/go-sqs-poller/worker/v5"
@@ -19,13 +20,13 @@ type SqsConfig struct {
 	WaitTimeSecond     int32  `split_words:"true" default:"20"`
 }
 
-func newSQSConsumer(ctx context.Context, conf *SqsConfig) *worker.Worker {
+func newSQSConsumer(ctx context.Context, conf *SqsConfig) (*worker.Worker, error) {
 	if conf.Debug == "true" {
 		appLogger.Level(logging.DebugLevel)
 	}
 	sqsClient, err := worker.CreateSqsClient(ctx, conf.AWSRegion, conf.SQSEndpoint)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to create a new client, %v", err)
+		return nil, fmt.Errorf("failed to create a new SQS client, %w", err)
 	}
 	return &worker.Worker{
 		Config: &worker.Config{
@@ -36,5 +37,5 @@ func newSQSConsumer(ctx context.Context, conf *SqsConfig) *worker.Worker {
 		},
 		Log:       appLogger,
 		SqsClient: sqsClient,
-	}
+	}, nil
 }


### PR DESCRIPTION
src/gitleaks配下のエラーハンドリング改善しました。

* client生成時のエラーは呼び出し元でハンドリングするために呼び出し元に返すようにしています。
* handleErrorWithUpdateStatusはステータスの更新とエラーのラッピングという二つの責務を持っていたので、見通しをよくするために分割しました。責務に合わせてメソッド名も変更しています。
* スキャン結果に紐づくデータ登録時にエラーが発生した場合、スキャンをエラーとして失敗するようにしています。また、返すエラーは元のエラーをラップするようにしています。