### PR TITLE
delete githubURL and author(adhoc)

### DIFF
--- a/pkg/gitleaks/finding.go
+++ b/pkg/gitleaks/finding.go
@@ -169,17 +169,11 @@ func GetRecommend(rule, repoName, fileName, visibility, githubURL, author, autho
 			repoName,
 			visibility,
 		),
-		Recommendation: fmt.Sprintf(`Take the following actions for leaked keys
+		Recommendation: `Take the following actions for leaked keys
 - Check the GitHub link for the key that has been committed.
-	- GitHub URL: %s
 - Check which environments the key has access to and what permissions it has (check with the Author of the commit if possible).
-	- Author: %s <%s>
 - Make sure you can rotate the key that has leaked.(If it is possible, do it immediately)
 - Reduce the number of roles associated with the leaked key or restrict the key's usage conditions
 - Next if the key activity can be confirmed from audit logs, etc., we will conduct a damage assessment.`,
-			githubURL,
-			author,
-			authorEmail,
-		),
 	}
 }

--- a/pkg/gitleaks/finding_test.go
+++ b/pkg/gitleaks/finding_test.go
@@ -289,9 +289,7 @@ func TestGetRecommend(t *testing.T) {
 - For example, they can break into the cloud platform, destroy critical resources, access or edit with sensitive data, and so on.`,
 				Recommendation: `Take the following actions for leaked keys
 - Check the GitHub link for the key that has been committed.
-	- GitHub URL: https://github.com/ca-risken/
 - Check which environments the key has access to and what permissions it has (check with the Author of the commit if possible).
-	- Author: ALICE <alice@example.com>
 - Make sure you can rotate the key that has leaked.(If it is possible, do it immediately)
 - Reduce the number of roles associated with the leaked key or restrict the key's usage conditions
 - Next if the key activity can be confirmed from audit logs, etc., we will conduct a damage assessment.`,


### PR DESCRIPTION
こちらのバグの暫定対応です。暫定対応によって、gitleaksスキャンが行われたタイミングでGithubURLとAuthorはRecommendが含まれなくなり、バグは暫定的に解消される認識です。

動作確認は文字列の変更しか含まないため、テスト確認のみ行なっています。

観点としては
- 動作確認が十分であるかどうか
などです。