### PR TITLE
Feature/fix type format

### DIFF
--- a/pkg/gitleaks/finding.go
+++ b/pkg/gitleaks/finding.go
@@ -161,10 +161,12 @@ type Recommend struct {
 func GetRecommend(rule, repoName, fileName, visibility, githubURL, author, authorEmail string) *Recommend {
 	return &Recommend{
 		Risk: fmt.Sprintf(`%s
-- Secret key has been saved in the file in the repository (%s repository)
+- Secret key has been saved in the %s file in the %s repository (%s repository)
 - If a key is leaked, a cyber attack is possible within the scope of the key's authority
 - For example, they can break into the cloud platform, destroy critical resources, access or edit with sensitive data, and so on.`,
 			rule,
+			fileName,
+			repoName,
 			visibility,
 		),
 		Recommendation: fmt.Sprintf(`Take the following actions for leaked keys

--- a/pkg/gitleaks/finding.go
+++ b/pkg/gitleaks/finding.go
@@ -167,12 +167,18 @@ func GetRecommend(rule, repoName, fileName, visibility, githubURL, author, autho
 			rule,
 			visibility,
 		),
-		Recommendation: `Take the following actions for leaked keys
+		Recommendation: fmt.Sprintf(`Take the following actions for leaked keys
 - Check the GitHub link for the key that has been committed.
+	- GitHub URL: %s
 - Check which environments the key has access to and what permissions it has (check with the Author of the commit if possible).
+	- Author: %s <%s>
 - Make sure you can rotate the key that has leaked.(If it is possible, do it immediately)
 - Reduce the number of roles associated with the leaked key or restrict the key's usage conditions
 - Next if the key activity can be confirmed from audit logs, etc., we will conduct a damage assessment.`,
+			githubURL,
+			author,
+			authorEmail,
+		),
 	}
 }
 

--- a/pkg/gitleaks/finding_test.go
+++ b/pkg/gitleaks/finding_test.go
@@ -289,7 +289,9 @@ func TestGetRecommend(t *testing.T) {
 - For example, they can break into the cloud platform, destroy critical resources, access or edit with sensitive data, and so on.`,
 				Recommendation: `Take the following actions for leaked keys
 - Check the GitHub link for the key that has been committed.
+	- GitHub URL: https://github.com/ca-risken/
 - Check which environments the key has access to and what permissions it has (check with the Author of the commit if possible).
+	- Author: ALICE <alice@example.com>
 - Make sure you can rotate the key that has leaked.(If it is possible, do it immediately)
 - Reduce the number of roles associated with the leaked key or restrict the key's usage conditions
 - Next if the key activity can be confirmed from audit logs, etc., we will conduct a damage assessment.`,

--- a/pkg/gitleaks/finding_test.go
+++ b/pkg/gitleaks/finding_test.go
@@ -284,7 +284,7 @@ func TestGetRecommend(t *testing.T) {
 			},
 			want: &Recommend{
 				Risk: `RULE
-- Secret key has been saved in the file in the repository (VISIBILITY repository)
+- Secret key has been saved in the FILE_NAME file in the REPO_NAME repository (VISIBILITY repository)
 - If a key is leaked, a cyber attack is possible within the scope of the key's authority
 - For example, they can break into the cloud platform, destroy critical resources, access or edit with sensitive data, and so on.`,
 				Recommendation: `Take the following actions for leaked keys

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -154,6 +154,7 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 			return mimosasqs.WrapNonRetryable(err)
 		}
 	}
+	s.logger.Errorf(ctx, "Hoge %d", msg.GitHubSettingID)
 	if err := s.updateScanStatusSuccess(ctx, scanStatus); err != nil {
 		return mimosasqs.WrapNonRetryable(err)
 	}
@@ -352,12 +353,10 @@ func (s *sqsHandler) putFindings(ctx context.Context, projectID uint32, findings
 			f.Result.Author,
 			f.Result.Email,
 		)
-
 		recommendTypeStr := fmt.Sprintf("%s-%s-%s-%s-%d-%d-%d", f.Result.RuleDescription, f.Result.Repo, f.Result.Commit, f.Result.File, f.Result.StartLine, f.Result.EndLine, f.Result.StartColumn)
-		recommendType := sha256.Sum256([]byte(recommendTypeStr))
-		hashInHex := hex.EncodeToString(recommendType[:])
-
-		err = s.putRecommend(ctx, resp.Finding.ProjectId, resp.Finding.FindingId, hashInHex, recommendContent)
+		recommendTypeBytes := sha256.Sum256([]byte(recommendTypeStr))
+		recommendType := hex.EncodeToString(recommendTypeBytes[:])
+		err = s.putRecommend(ctx, resp.Finding.ProjectId, resp.Finding.FindingId, recommendType, recommendContent)
 		if err != nil {
 			return err
 		}

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -154,7 +154,6 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 			return mimosasqs.WrapNonRetryable(err)
 		}
 	}
-	s.logger.Errorf(ctx, "Hoge %d", msg.GitHubSettingID)
 	if err := s.updateScanStatusSuccess(ctx, scanStatus); err != nil {
 		return mimosasqs.WrapNonRetryable(err)
 	}

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -350,7 +352,12 @@ func (s *sqsHandler) putFindings(ctx context.Context, projectID uint32, findings
 			f.Result.Author,
 			f.Result.Email,
 		)
-		err = s.putRecommend(ctx, resp.Finding.ProjectId, resp.Finding.FindingId, f.Result.RuleDescription, recommendContent)
+
+		recommendTypeStr := fmt.Sprintf("%s-%s-%s-%s-%d-%d-%d", f.Result.RuleDescription, f.Result.Repo, f.Result.Commit, f.Result.File, f.Result.StartLine, f.Result.EndLine, f.Result.StartColumn)
+		recommendType := sha256.Sum256([]byte(recommendTypeStr))
+		hashInHex := hex.EncodeToString(recommendType[:])
+
+		err = s.putRecommend(ctx, resp.Finding.ProjectId, resp.Finding.FindingId, hashInHex, recommendContent)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
gitleaksにおいて、(datasource, type)がRecommendのユニークキーとして不適になる問題がありました。
https://github.com/ca-risken/common/blob/master/middleware/db/01_ddl_mimosa.sql#L194

type=Ruleとすると、RuleとRecommendのコンテンツが１対１対応することになります。Recommendのコンテンツに、GithubURLが含んでいるため、RecommendのコンテンツはGithubURLと１対１対応する必要があります。

今回のPRでは、(datasource, type)がdatasource=gitleaksの場合でもRecommend情報を特定でき、ユニークとなるようにすしています。

またこの修正に合わせて、消去していたRecommendのコンテンツを復旧しています。

観点
- typeが無意味な16進数になるため、UXを損なわないか
- typeに含める情報はこれでよいか