### PR TITLE
fix: semgrep score

### DIFF
--- a/pkg/codescan/finding.go
+++ b/pkg/codescan/finding.go
@@ -71,6 +71,7 @@ func GeneratePutFindingRequest(projectID uint32, f *SemgrepFinding) (*finding.Pu
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal data: project_id=%d, repository=%s, err=%w", projectID, f.Repository, err)
 	}
+	meta := extractSemgrepMetadata(f.Extra.Metadata)
 	return &finding.PutFindingRequest{
 		ProjectId: projectID,
 		Finding: &finding.FindingForUpsert{
@@ -79,7 +80,7 @@ func GeneratePutFindingRequest(projectID uint32, f *SemgrepFinding) (*finding.Pu
 			DataSourceId:     GenerateDataSourceIDForSemgrep(f),
 			ResourceName:     f.Repository,
 			ProjectId:        projectID,
-			OriginalScore:    GetScoreSemgrep(f.Extra.Severity),
+			OriginalScore:    GetScoreSemgrep(f.Extra.Severity, meta.Likelihood, meta.Impact),
 			OriginalMaxScore: 1.0,
 			Data:             string(buf),
 		},

--- a/pkg/codescan/finding_test.go
+++ b/pkg/codescan/finding_test.go
@@ -29,8 +29,9 @@ func TestGeneratePutFindingRequest(t *testing.T) {
 					Path:       "path/to/file",
 					CheckID:    "check_id",
 					Extra: &SemgrepExtra{
-						Message: "message",
-						Lines:   "lines",
+						Message:  "message",
+						Lines:    "lines",
+						Metadata: `{"key":"value"}`,
 					},
 					Start: &SemgrepLine{
 						Line:   1,
@@ -52,7 +53,7 @@ func TestGeneratePutFindingRequest(t *testing.T) {
 					ProjectId:        1,
 					OriginalScore:    0,
 					OriginalMaxScore: 1.0,
-					Data:             `{"repository":"org/repo","check_id":"check_id","path":"path/to/file","start":{"line":1,"col":1},"end":{"line":1,"col":1},"extra":{"lines":"lines","message":"message"}}`,
+					Data:             `{"repository":"org/repo","check_id":"check_id","path":"path/to/file","start":{"line":1,"col":1},"end":{"line":1,"col":1},"extra":{"lines":"lines","message":"message","metadata":"{\"key\":\"value\"}"}}`,
 				},
 			},
 			wantErr: false,

--- a/pkg/codescan/handler.go
+++ b/pkg/codescan/handler.go
@@ -68,7 +68,6 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 		return mimosasqs.WrapNonRetryable(err)
 	}
 
-	beforeScanAt := time.Now()
 	gitHubSetting, err := s.getGitHubSetting(ctx, msg.ProjectID, msg.GitHubSettingID)
 	if err != nil {
 		s.logger.Errorf(ctx, "Failed to get scan setting: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
@@ -96,6 +95,7 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 	// Filtered By Name
 	repos = filterByNamePattern(repos, gitHubSetting.CodeScanSetting.RepositoryPattern)
 
+	beforeScanAt := time.Now()
 	semgrepFindings := []*SemgrepFinding{}
 	for _, r := range repos {
 		if s.skipScan(ctx, r, s.limitRepositorySizeKb) {

--- a/pkg/codescan/handler.go
+++ b/pkg/codescan/handler.go
@@ -121,7 +121,7 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 	for _, r := range repos {
 		repo := r.GetFullName()
 		if _, err := s.findingClient.ClearScore(ctx, &finding.ClearScoreRequest{
-			DataSource: message.GoogleCloudSploitDataSource,
+			DataSource: message.CodeScanDataSource,
 			ProjectId:  msg.ProjectID,
 			Tag:        []string{tagCodeScan, repo},
 			BeforeAt:   beforeScanAt.Unix(),

--- a/pkg/codescan/handler.go
+++ b/pkg/codescan/handler.go
@@ -102,7 +102,7 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 		}
 
 		// Scan source code
-		scanResult, err := s.scanForRepository(ctx, msg.ProjectID, r, token, gitHubSetting.BaseUrl)
+		scanResult, err := s.scanForRepository(ctx, r, token, gitHubSetting.BaseUrl)
 		if err != nil {
 			s.logger.Errorf(ctx, "failed to codeScan scan: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
 			s.updateStatusToError(ctx, scanStatus, err)

--- a/pkg/codescan/semgrep.go
+++ b/pkg/codescan/semgrep.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/go-github/v44/github"
 )
 
-func (s *sqsHandler) scanForRepository(ctx context.Context, projectID uint32, r *github.Repository, token, githubBaseURL string) ([]*SemgrepFinding, error) {
+func (s *sqsHandler) scanForRepository(ctx context.Context, r *github.Repository, token, githubBaseURL string) ([]*SemgrepFinding, error) {
 	// Clone repository
 	dir, err := createCloneDir(*r.Name)
 	if err != nil {
@@ -82,10 +82,27 @@ func ParseSemgrepResult(dir, scanResult, repository, masterBranch, githubBaseURL
 	return findings, nil
 }
 
-func GetScoreSemgrep(serverity string) float32 {
+func extractSemgrepMetadata(metadata any) *SemgrepMetadata {
+	meta, ok := metadata.(map[string]interface{})
+	if !ok {
+		return &SemgrepMetadata{}
+	}
+
+	var m SemgrepMetadata
+	if v, ok := meta["likelihood"]; ok {
+		m.Likelihood = fmt.Sprintf("%v", v)
+	}
+	if v, ok := meta["impact"]; ok {
+		m.Impact = fmt.Sprintf("%v", v)
+	}
+	return &m
+}
+
+func GetScoreSemgrep(serverity, likelihood, impact string) float32 {
+	var score float32
 	switch serverity {
 	case "ERROR":
-		return 0.6
+		score = 0.3 // base score
 	case "WARNING":
 		return 0.3
 	case "INFO":
@@ -93,6 +110,24 @@ func GetScoreSemgrep(serverity string) float32 {
 	default:
 		return 0.0
 	}
+	if likelihood == "" && impact == "" {
+		return 0.6 // Simple ERROR score (not security finding)
+	}
+
+	// Fine-grained scoring
+	switch likelihood {
+	case "HIGH":
+		score += 0.2
+	case "MEDIUM":
+		score += 0.1
+	}
+	switch impact {
+	case "HIGH":
+		score += 0.2
+	case "MEDIUM":
+		score += 0.1
+	}
+	return score
 }
 
 func GenerateDataSourceIDForSemgrep(f *SemgrepFinding) string {
@@ -137,4 +172,12 @@ type SemgrepExtra struct {
 	Severity      string      `json:"severity,omitempty"`
 	ValidateState string      `json:"validate_state,omitempty"`
 	Metadata      interface{} `json:"metadata,omitempty"`
+}
+
+// SemgrepMetadata is a struct for semgrep metadata.
+// If `security` category, a metadata has `likelihood` and `impact` fields(required fields).
+// refs: https://semgrep.dev/docs/contributing/contributing-to-semgrep-rules-repository/#including-fields-required-by-security-category
+type SemgrepMetadata struct {
+	Likelihood string `json:"likelihood,omitempty"`
+	Impact     string `json:"impact,omitempty"`
 }

--- a/pkg/codescan/semgrep.go
+++ b/pkg/codescan/semgrep.go
@@ -110,9 +110,6 @@ func GetScoreSemgrep(serverity, likelihood, impact string) float32 {
 	}
 
 	// severity "ERROR"
-	if impact == "" && likelihood == "" {
-		return 0.6 // Simple ERROR score (not security finding)
-	}
 
 	// Fine-grained scoring
 	// TODO: comment in
@@ -126,7 +123,7 @@ func GetScoreSemgrep(serverity, likelihood, impact string) float32 {
 	} else if impact == "LOW" {
 		return 0.4
 	}
-	return 0.0
+	return 0.6 // default ERROR score
 }
 
 func GenerateDataSourceIDForSemgrep(f *SemgrepFinding) string {

--- a/pkg/codescan/semgrep.go
+++ b/pkg/codescan/semgrep.go
@@ -99,35 +99,34 @@ func extractSemgrepMetadata(metadata any) *SemgrepMetadata {
 }
 
 func GetScoreSemgrep(serverity, likelihood, impact string) float32 {
-	var score float32
 	switch serverity {
-	case "ERROR":
-		score = 0.3 // base score
 	case "WARNING":
 		return 0.3
 	case "INFO":
 		return 0.1
-	default:
+	}
+	if serverity != "ERROR" {
 		return 0.0
 	}
-	if likelihood == "" && impact == "" {
+
+	// severity "ERROR"
+	if impact == "" && likelihood == "" {
 		return 0.6 // Simple ERROR score (not security finding)
 	}
 
 	// Fine-grained scoring
-	switch likelihood {
-	case "HIGH":
-		score += 0.2
-	case "MEDIUM":
-		score += 0.1
+	// TODO: comment in
+	// if impact == "HIGH" && likelihood == "HIGH" {
+	// 	return 0.8
+	// }
+	if impact == "HIGH" {
+		return 0.6
+	} else if impact == "MEDIUM" {
+		return 0.5
+	} else if impact == "LOW" {
+		return 0.4
 	}
-	switch impact {
-	case "HIGH":
-		score += 0.2
-	case "MEDIUM":
-		score += 0.1
-	}
-	return score
+	return 0.0
 }
 
 func GenerateDataSourceIDForSemgrep(f *SemgrepFinding) string {

--- a/pkg/codescan/semgrep_test.go
+++ b/pkg/codescan/semgrep_test.go
@@ -77,86 +77,42 @@ func TestGetScoreSemgrep(t *testing.T) {
 		input *args
 		want  float32
 	}{
+		// TODO: comment in
+		// {
+		// 	name: "ERROR(impact: HIGH, likelihood: HIGH)",
+		// 	input: &args{
+		// 		serverity:  "ERROR",
+		// 		likelihood: "HIGH",
+		// 		impact:     "HIGH",
+		// 	},
+		// 	want: 0.8,
+		// },
 		{
-			name: "ERROR(likelihood: HIGH, impact: HIGH)",
+			name: "ERROR(impact: HIGN, likelihood: not HIGH)",
 			input: &args{
 				serverity:  "ERROR",
-				likelihood: "HIGH",
 				impact:     "HIGH",
-			},
-			want: 0.7,
-		},
-		{
-			name: "ERROR(likelihood: HIGH, impact: MEDIUM)",
-			input: &args{
-				serverity:  "ERROR",
-				likelihood: "HIGH",
-				impact:     "MEDIUM",
+				likelihood: "LOW",
 			},
 			want: 0.6,
 		},
 		{
-			name: "ERROR(likelihood: HIGH, impact: LOW)",
+			name: "ERROR(impact: MEDIUM, likelihood: not HIGH)",
 			input: &args{
 				serverity:  "ERROR",
-				likelihood: "HIGH",
-				impact:     "LOW",
-			},
-			want: 0.5,
-		},
-		{
-			name: "ERROR(likelihood: MEDIUM, impact: HIGH)",
-			input: &args{
-				serverity:  "ERROR",
-				likelihood: "MEDIUM",
-				impact:     "HIGH",
-			},
-			want: 0.6,
-		},
-		{
-			name: "ERROR(likelihood: MEDIUM, impact: MEDIUM)",
-			input: &args{
-				serverity:  "ERROR",
-				likelihood: "MEDIUM",
 				impact:     "MEDIUM",
+				likelihood: "LOW",
 			},
 			want: 0.5,
 		},
 		{
-			name: "ERROR(likelihood: MEDIUM, impact: LOW)",
+			name: "ERROR(impact: LOW, likelihood: not HIGH)",
 			input: &args{
 				serverity:  "ERROR",
-				likelihood: "MEDIUM",
 				impact:     "LOW",
+				likelihood: "LOW",
 			},
 			want: 0.4,
-		},
-		{
-			name: "ERROR(likelihood: LOW, impact: HIGH)",
-			input: &args{
-				serverity:  "ERROR",
-				likelihood: "LOW",
-				impact:     "HIGH",
-			},
-			want: 0.5,
-		},
-		{
-			name: "ERROR(likelihood: LOW, impact: MEDIUM)",
-			input: &args{
-				serverity:  "ERROR",
-				likelihood: "LOW",
-				impact:     "MEDIUM",
-			},
-			want: 0.4,
-		},
-		{
-			name: "ERROR(likelihood: LOW, impact: LOW)",
-			input: &args{
-				serverity:  "ERROR",
-				likelihood: "LOW",
-				impact:     "LOW",
-			},
-			want: 0.3,
 		},
 		{
 			name: "WARNING",


### PR DESCRIPTION
Semgrepの公式ドキュメントを見ると、Findingの重大度は「Likelihood（Low-Midium-High）」と「Impact（Low-Midium-High）」のかけあわせで、Low-Midium-Highを計算するそうです。

https://semgrep.dev/docs/semgrep-code/findings/
> Severity	Filter by the severity of a finding. Severity is computed based on the values assigned for [Likelihood](https://semgrep.dev/docs/contributing/contributing-to-semgrep-rules-repository/#likelihood) and [Impact](https://semgrep.dev/docs/contributing/contributing-to-semgrep-rules-repository/#impact) by the rule's author. Possible values:
Low
Medium
High

RISKENもSemgrepの公式に従って、上記の２種類を見るのはどうかというPR。


## 現状

もともとServerityという項目があって、こちらをみています
https://semgrep.dev/docs/writing-rules/rule-syntax/

- ERROR: 0.6
- WARNING: 0.3
- INFO: 0.1

ただ、実際のデータをみると、ERRORは結構ある
が、LikelihoodとImpactがLowのものも中には結構あって、実態とより合う形にしたい。

## 案

検出されたデータを見ると特にImpactがHighかどうかで、内容の重大度に違いがあったため、Impactを見てスコアを変動させる。

また、あわせて、ソースコードを修正してもFindingが残ったままになってしまう問題があったのでクリアスコア処理を入れます。