### PR TITLE
fix: list user repos

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -132,16 +132,13 @@ func (g *riskenGitHubClient) listRepositoryForUserWithOption(ctx context.Context
 		Type:        githubVisibilityAll,
 	}
 	for {
-		repos, resp, err := repository.List(ctx, "", opt) // user: Passing the empty string will list repositories for the authenticated user.
+		repos, resp, err := repository.List(ctx, login, opt)
 		if err != nil {
 			return nil, err
 		}
 		g.logger.Infof(ctx, "Success GitHub API for user repos, %s,login:%s, option:%+v, repo_count: %d, response:%+v", login, opt, len(repos), resp)
-		for _, r := range repos {
-			if *r.Owner.Login == login {
-				allRepo = append(allRepo, r)
-			}
-		}
+		allRepo = append(allRepo, repos...)
+
 		if resp.NextPage == 0 {
 			break
 		}

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -70,7 +70,7 @@ func Test_listRepositoryForUserWithOption(t *testing.T) {
 			want: []*github.Repository{
 				{
 					Name:  PointerString("repo"),
-					Owner: &github.User{Login: PointerString("onwer")},
+					Owner: &github.User{Login: PointerString("owner")},
 				},
 			},
 		},
@@ -121,19 +121,13 @@ func Test_listRepositoryForOrgWithOption(t *testing.T) {
 			want: []*github.Repository{
 				{
 					Name:  PointerString("repo"),
-					Owner: &github.User{Login: PointerString("onwer")},
+					Owner: &github.User{Login: PointerString("owner")},
 				},
 			},
 		},
 		{
 			name:       "OK empty",
 			repository: newfakeGitHubRepoService(true, "", "", nil),
-			want:       []*github.Repository{},
-		},
-		{
-			name:       "OK empty(owner mismatch)",
-			login:      "fakeuser",
-			repository: newfakeGitHubRepoService(false, "repo", "owner", nil),
 			want:       []*github.Repository{},
 		},
 		{
@@ -148,7 +142,7 @@ func Test_listRepositoryForOrgWithOption(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			ctx := context.Background()
 			githubClient := NewGithubClient("token", logging.NewLogger())
-			got, err := githubClient.listRepositoryForUserWithOption(ctx, c.repository, c.login)
+			got, err := githubClient.listRepositoryForOrgWithOption(ctx, c.repository, c.login)
 			if c.wantError && err == nil {
 				t.Fatal("Unexpected no error")
 			}


### PR DESCRIPTION
ユーザのリポジトリのList APIですが、authenticated userのみのリポジトリしか検索できない状態になっていました。
つまり、他のuserのリポジトリは検索できない＝バグを修正します。