### PR TITLE
fix: user repos filter

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -137,7 +137,12 @@ func (g *riskenGitHubClient) listRepositoryForUserWithOption(ctx context.Context
 			return nil, err
 		}
 		g.logger.Infof(ctx, "Success GitHub API for user repos, %s,login:%s, option:%+v, repo_count: %d, response:%+v", login, opt, len(repos), resp)
-		allRepo = append(allRepo, repos...)
+		for _, r := range repos {
+			// Filter repositories by user owner
+			if r.Owner != nil && r.Owner.Login != nil && *r.Owner.Login == login {
+				allRepo = append(allRepo, r)
+			}
+		}
 
 		if resp.NextPage == 0 {
 			break


### PR DESCRIPTION
Userのリポジトリ検索の場合、そのユーザがAuthorになっているリポジトリ含めて取得されてしまうため、対象範囲が想定以上に広がる可能性があります。
（例えばどこかのOrgのAuthorの場合そちらも拾ってしまう）

対象リポジトリを収集する際に、自分自身かどうかのチェックをいれるようにすることで余計なリポジトリが含まれないよう調整します