### PR TITLE
[mod]sqs-error

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -137,7 +137,7 @@ func (g *riskenGitHubClient) ListRepository(ctx context.Context, config *code.Gi
 		g.setRepoListCache(config, repos)
 		for _, r := range repos {
 			if r.FullName != nil && *r.FullName == repoName {
-				return []*github.Repository{r}, nil
+				return []*github.Repository{g.copyRepository(r)}, nil
 			}
 		}
 		// Fallback: Repositories.Get for fine-grained PATs where list may not return all accessible repos
@@ -160,8 +160,8 @@ func (g *riskenGitHubClient) ListRepository(ctx context.Context, config *code.Gi
 func (g *riskenGitHubClient) getRepoFromCache(config *code.GitHubSetting, repoName string) *github.Repository {
 	key := g.repoListCacheKey(config)
 	g.repoListCacheMu.RLock()
+	defer g.repoListCacheMu.RUnlock()
 	entry, ok := g.repoListCache[key]
-	g.repoListCacheMu.RUnlock()
 	if !ok || time.Since(entry.fetchedAt) > repoListCacheTTL {
 		return nil
 	}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -2,6 +2,8 @@ package github
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/url"
 	"sync"
@@ -105,7 +107,10 @@ func (g *riskenGitHubClient) Clone(ctx context.Context, token string, cloneURL s
 }
 
 func (g *riskenGitHubClient) repoListCacheKey(config *code.GitHubSetting) string {
-	return fmt.Sprintf("%s|%s|%s", config.Type.String(), config.TargetResource, config.BaseUrl)
+	token := getToken(config.PersonalAccessToken, g.defaultToken)
+	hash := sha256.Sum256([]byte(token))
+	tokenHash := hex.EncodeToString(hash[:])[:16] // First 16 chars for uniqueness without exposing full hash
+	return fmt.Sprintf("%s|%s|%s|%s", config.Type.String(), config.TargetResource, config.BaseUrl, tokenHash)
 }
 
 func (g *riskenGitHubClient) ListRepository(ctx context.Context, config *code.GitHubSetting, repoName string) ([]*github.Repository, error) {


### PR DESCRIPTION
gitleaksにおいて、sqsのメッセージ処理でエラーが出ている件について、
- 原因
  - GitHub APIの呼び出しのrate limitに引っかかっている
- 対策
  - ListRepositoryを呼び出した際にUser/Orgに紐づくリポジトリ全件を取得し、キャッシュリスト化してAPI呼び出し効率を上げる(既存はメッセージ1件ごとにGitHub APIを呼び出す構成になっていた)

ローカルで動作確認済み
  ```
Repository ca-risken/risken-mcp-server found in cache, skipped GitHub API call
  Repository ca-risken/operation found in cache, skipped GitHub API call
  Repository ca-risken/terraform-sandbox found in cache, skipped GitHub API call
  Repository ca-risken/security-review found in cache, skipped GitHub API call
  Repository ca-risken/actions-test found in cache, skipped GitHub API call
  Repository ca-risken/go-risken found in cache, skipped GitHub API call
  Repository ca-risken/azure found in cache, skipped GitHub API call
  Repository ca-risken/.github found in cache, skipped GitHub API call
  Repository ca-risken/security-review-test found in cache, skipped GitHub API call
  Repository ca-risken/vulnerability found in cache, skipped GitHub API call
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ca-risken/code/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
