### PR TITLE
[add]gitleaks-use-repositories-from-queue-message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/ca-risken/common/pkg/sqs v0.0.0-20221119073224-9db027bda6f8
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20251104095036-403011f05377
 	github.com/ca-risken/core v0.16.0
-	github.com/ca-risken/datasource-api v0.16.1-0.20260119073340-7ba515c97730
+	github.com/ca-risken/datasource-api v0.16.1-0.20260220012639-3a8f1da0d63c
 	github.com/ca-risken/go-sqs-poller/worker/v5 v5.0.0-20220525093235-9148d33b6aee
 	github.com/ca-risken/vulnerability v0.0.0-20250207144506-e2bcae88c3dc
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/zricethezav/gitleaks/v8 v8.8.6
 	golang.org/x/oauth2 v0.33.0
 	google.golang.org/grpc v1.77.0
-	google.golang.org/protobuf v1.36.10
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 )
 
@@ -185,6 +184,7 @@ require (
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251111163417-95abcf5c77ba // indirect
+	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/DataDog/dd-trace-go.v1 v1.74.8 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/ca-risken/core v0.16.0 h1:Xi5dZvyrL7Cz/a2mOHw5c77QFjzlj/Oggbdd02q3bTI
 github.com/ca-risken/core v0.16.0/go.mod h1:hKlz8v1FofEEPK0AMerb8itPJdf6iRoB7C5ja9qaJ6o=
 github.com/ca-risken/datasource-api v0.16.1-0.20260119073340-7ba515c97730 h1:I+A16TnvFOJonY/ojpSx5byPKMEczlVkyBw1llGTOVQ=
 github.com/ca-risken/datasource-api v0.16.1-0.20260119073340-7ba515c97730/go.mod h1:e1qGlJqPJH+dqdwjPsB7ssrJ9wVTwtdYrwohNLl3TfA=
+github.com/ca-risken/datasource-api v0.16.1-0.20260220012639-3a8f1da0d63c h1:lQYaUjw4EtJzesmmp6EmZaJH81gaxv1PbMySsrTfpOo=
+github.com/ca-risken/datasource-api v0.16.1-0.20260220012639-3a8f1da0d63c/go.mod h1:e1qGlJqPJH+dqdwjPsB7ssrJ9wVTwtdYrwohNLl3TfA=
 github.com/ca-risken/go-sqs-poller/worker/v5 v5.0.0-20220525093235-9148d33b6aee h1:aIrvjCnF+Owzzh7dnE1w4442CdcuUkHaJsJOXImjeqg=
 github.com/ca-risken/go-sqs-poller/worker/v5 v5.0.0-20220525093235-9148d33b6aee/go.mod h1:pboVfH7X3jKqsVKSpYNYAgqgPQ6gVb+AjFuWH1e8dSU=
 github.com/ca-risken/vulnerability v0.0.0-20250207144506-e2bcae88c3dc h1:KE/GJPDp15Dybl/BIh1OzwOAYfJ3euNimTLfuz7KC1E=

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,6 @@ github.com/ca-risken/common/pkg/tracer v0.0.0-20251104095036-403011f05377 h1:7eJ
 github.com/ca-risken/common/pkg/tracer v0.0.0-20251104095036-403011f05377/go.mod h1:c6ENRTqNN5hOCB85fZHvEjMhDWt87dpN20Wz6j91InU=
 github.com/ca-risken/core v0.16.0 h1:Xi5dZvyrL7Cz/a2mOHw5c77QFjzlj/Oggbdd02q3bTI=
 github.com/ca-risken/core v0.16.0/go.mod h1:hKlz8v1FofEEPK0AMerb8itPJdf6iRoB7C5ja9qaJ6o=
-github.com/ca-risken/datasource-api v0.16.1-0.20260119073340-7ba515c97730 h1:I+A16TnvFOJonY/ojpSx5byPKMEczlVkyBw1llGTOVQ=
-github.com/ca-risken/datasource-api v0.16.1-0.20260119073340-7ba515c97730/go.mod h1:e1qGlJqPJH+dqdwjPsB7ssrJ9wVTwtdYrwohNLl3TfA=
 github.com/ca-risken/datasource-api v0.16.1-0.20260220012639-3a8f1da0d63c h1:lQYaUjw4EtJzesmmp6EmZaJH81gaxv1PbMySsrTfpOo=
 github.com/ca-risken/datasource-api v0.16.1-0.20260220012639-3a8f1da0d63c/go.mod h1:e1qGlJqPJH+dqdwjPsB7ssrJ9wVTwtdYrwohNLl3TfA=
 github.com/ca-risken/go-sqs-poller/worker/v5 v5.0.0-20220525093235-9148d33b6aee h1:aIrvjCnF+Owzzh7dnE1w4442CdcuUkHaJsJOXImjeqg=

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -222,12 +222,12 @@ func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.Code
 	s.logger.Infof(ctx, "Got repositories from queue message, count=%d, baseURL=%s, target=%s",
 		len(repos), gitHubSetting.BaseUrl, gitHubSetting.TargetResource)
 
-	return s.scanDiffRepositories(ctx, msg, token, repos)
+	return s.scanDiffRepositories(ctx, msg, token, repos, gitHubSetting.BaseUrl)
 }
 
-func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.CodeQueueMessage, token string, repos []*github.Repository) error {
+func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.CodeQueueMessage, token string, repos []*github.Repository, githubBaseURL string) error {
 	for _, r := range repos {
-		if err := validateRepository(r); err != nil {
+		if err := validateRepository(r, githubBaseURL); err != nil {
 			repoFullName := ""
 			if r != nil {
 				repoFullName = r.GetFullName()

--- a/pkg/gitleaks/handler_test.go
+++ b/pkg/gitleaks/handler_test.go
@@ -108,9 +108,15 @@ func TestValidateRepository_CloneURLValidation(t *testing.T) {
 		},
 		{
 			name:    "enterprise host accepted",
-			repo:    func() *github.Repository { r := *baseRepo; r.CloneURL = github.String("https://github.example.com/owner/repo.git"); return &r }(),
+			repo:    func() *github.Repository { r := *baseRepo; r.CloneURL = github.String("https://github.example.com/owner/repo.git"); r.HTMLURL = github.String("https://github.example.com/owner/repo"); return &r }(),
 			baseURL: "https://github.example.com/api/v3/",
 			wantErr: false,
+		},
+		{
+			name:    "enterprise mode rejects github.com clone_url",
+			repo:    func() *github.Repository { r := *baseRepo; r.CloneURL = github.String("https://github.com/owner/repo.git"); return &r }(),
+			baseURL: "https://github.example.com/api/v3/",
+			wantErr: true,
 		},
 		{
 			name:    "html_url invalid scheme",

--- a/pkg/gitleaks/handler_test.go
+++ b/pkg/gitleaks/handler_test.go
@@ -53,22 +53,13 @@ func TestGetRepositoriesFromCodeQueueMessage(t *testing.T) {
 	})
 }
 
-func TestValidateRepositoriesForFilter(t *testing.T) {
+func TestValidateRepository(t *testing.T) {
 	repo := &github.Repository{
 		Name:       github.String("repo"),
 		FullName:   github.String("owner/repo"),
+		CloneURL:   github.String("https://github.com/owner/repo.git"),
 		Visibility: github.String("private"),
-	}
-	if err := validateRepositoriesForFilter([]*github.Repository{repo}); err != nil {
-		t.Fatalf("unexpected error: %+v", err)
-	}
-}
-
-func TestValidateRepositoryForScan(t *testing.T) {
-	repo := &github.Repository{
-		CloneURL: github.String("https://github.com/owner/repo.git"),
-		FullName: github.String("owner/repo"),
-		HTMLURL:  github.String("https://github.com/owner/repo"),
+		HTMLURL:    github.String("https://github.com/owner/repo"),
 		CreatedAt: &github.Timestamp{
 			Time: time.Now().Add(-1 * time.Hour),
 		},
@@ -76,7 +67,7 @@ func TestValidateRepositoryForScan(t *testing.T) {
 			Time: time.Now(),
 		},
 	}
-	if err := validateRepositoryForScan(repo); err != nil {
+	if err := validateRepository(repo); err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}
 }

--- a/pkg/gitleaks/repository_validation.go
+++ b/pkg/gitleaks/repository_validation.go
@@ -2,11 +2,13 @@ package gitleaks
 
 import (
 	"fmt"
+	"net/url"
+	"strings"
 
 	"github.com/google/go-github/v44/github"
 )
 
-func validateRepository(repo *github.Repository) error {
+func validateRepository(repo *github.Repository, githubBaseURL string) error {
 	if repo == nil {
 		return fmt.Errorf("invalid repository metadata: repository is nil")
 	}
@@ -31,5 +33,85 @@ func validateRepository(repo *github.Repository) error {
 	if repo.HTMLURL == nil || *repo.HTMLURL == "" {
 		return fmt.Errorf("invalid repository metadata: html_url is required, repository=%s", repo.GetFullName())
 	}
+	if err := validateCloneURL(repo.GetCloneURL(), repo.GetFullName(), githubBaseURL); err != nil {
+		return err
+	}
+	if err := validateHTMLURL(repo.GetHTMLURL(), repo.GetFullName(), githubBaseURL); err != nil {
+		return err
+	}
 	return nil
+}
+
+func validateCloneURL(cloneURL, repoFullName, githubBaseURL string) error {
+	u, err := url.Parse(cloneURL)
+	if err != nil {
+		return fmt.Errorf("invalid repository metadata: clone_url parse error: clone_url=%s, err=%w", cloneURL, err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("invalid repository metadata: clone_url scheme must be https: clone_url=%s", cloneURL)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("invalid repository metadata: clone_url host is required: clone_url=%s", cloneURL)
+	}
+
+	allowedHosts := allowedCloneHosts(githubBaseURL)
+	if _, ok := allowedHosts[strings.ToLower(u.Hostname())]; !ok {
+		return fmt.Errorf("invalid repository metadata: clone_url host is not allowed: clone_url=%s, allowed_hosts=%v", cloneURL, keys(allowedHosts))
+	}
+
+	normalizedPath := strings.TrimPrefix(u.EscapedPath(), "/")
+	normalizedPath = strings.TrimSuffix(normalizedPath, ".git")
+	if normalizedPath != repoFullName {
+		return fmt.Errorf("invalid repository metadata: clone_url path does not match repository full_name: clone_url=%s, repository_full_name=%s", cloneURL, repoFullName)
+	}
+	return nil
+}
+
+func validateHTMLURL(htmlURL, repoFullName, githubBaseURL string) error {
+	u, err := url.Parse(htmlURL)
+	if err != nil {
+		return fmt.Errorf("invalid repository metadata: html_url parse error: html_url=%s, err=%w", htmlURL, err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("invalid repository metadata: html_url scheme must be https: html_url=%s", htmlURL)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("invalid repository metadata: html_url host is required: html_url=%s", htmlURL)
+	}
+
+	allowedHosts := allowedCloneHosts(githubBaseURL)
+	if _, ok := allowedHosts[strings.ToLower(u.Hostname())]; !ok {
+		return fmt.Errorf("invalid repository metadata: html_url host is not allowed: html_url=%s, allowed_hosts=%v", htmlURL, keys(allowedHosts))
+	}
+
+	normalizedPath := strings.TrimPrefix(u.EscapedPath(), "/")
+	if normalizedPath != repoFullName {
+		return fmt.Errorf("invalid repository metadata: html_url path does not match repository full_name: html_url=%s, repository_full_name=%s", htmlURL, repoFullName)
+	}
+	return nil
+}
+
+func allowedCloneHosts(githubBaseURL string) map[string]struct{} {
+	hosts := map[string]struct{}{"github.com": {}}
+	if githubBaseURL == "" {
+		return hosts
+	}
+	u, err := url.Parse(githubBaseURL)
+	if err != nil || u.Hostname() == "" {
+		return hosts
+	}
+	host := strings.ToLower(u.Hostname())
+	hosts[host] = struct{}{}
+	if strings.HasPrefix(host, "api.") {
+		hosts[strings.TrimPrefix(host, "api.")] = struct{}{}
+	}
+	return hosts
+}
+
+func keys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }

--- a/pkg/gitleaks/repository_validation.go
+++ b/pkg/gitleaks/repository_validation.go
@@ -92,10 +92,10 @@ func validateHTMLURL(htmlURL, repoFullName, githubBaseURL string) error {
 }
 
 func allowedCloneHosts(githubBaseURL string) map[string]struct{} {
-	hosts := map[string]struct{}{"github.com": {}}
 	if githubBaseURL == "" {
-		return hosts
+		return map[string]struct{}{"github.com": {}}
 	}
+	hosts := make(map[string]struct{})
 	u, err := url.Parse(githubBaseURL)
 	if err != nil || u.Hostname() == "" {
 		return hosts

--- a/pkg/gitleaks/repository_validation.go
+++ b/pkg/gitleaks/repository_validation.go
@@ -6,27 +6,18 @@ import (
 	"github.com/google/go-github/v44/github"
 )
 
-func validateRepositoriesForFilter(repos []*github.Repository) error {
-	for _, r := range repos {
-		if r == nil {
-			return fmt.Errorf("invalid repository metadata: repository is nil")
-		}
-		if r.Name == nil || *r.Name == "" {
-			return fmt.Errorf("invalid repository metadata: name is required")
-		}
-		if r.FullName == nil || *r.FullName == "" {
-			return fmt.Errorf("invalid repository metadata: full_name is required")
-		}
-		if r.Visibility == nil || *r.Visibility == "" {
-			return fmt.Errorf("invalid repository metadata: visibility is required, repository=%s", r.GetFullName())
-		}
-	}
-	return nil
-}
-
-func validateRepositoryForScan(repo *github.Repository) error {
+func validateRepository(repo *github.Repository) error {
 	if repo == nil {
 		return fmt.Errorf("invalid repository metadata: repository is nil")
+	}
+	if repo.Name == nil || *repo.Name == "" {
+		return fmt.Errorf("invalid repository metadata: name is required")
+	}
+	if repo.FullName == nil || *repo.FullName == "" {
+		return fmt.Errorf("invalid repository metadata: full_name is required")
+	}
+	if repo.Visibility == nil || *repo.Visibility == "" {
+		return fmt.Errorf("invalid repository metadata: visibility is required, repository=%s", repo.GetFullName())
 	}
 	if repo.CloneURL == nil || *repo.CloneURL == "" {
 		return fmt.Errorf("invalid repository metadata: clone_url is required, repository=%s", repo.GetFullName())

--- a/pkg/gitleaks/repository_validation.go
+++ b/pkg/gitleaks/repository_validation.go
@@ -32,10 +32,10 @@ func validateRepositoryForScan(repo *github.Repository) error {
 		return fmt.Errorf("invalid repository metadata: clone_url is required, repository=%s", repo.GetFullName())
 	}
 	if repo.CreatedAt == nil {
-		return fmt.Errorf("invalid repository metadata: created_at is required, repository=%s", repo.GetFullName())
+		return fmt.Errorf("invalid repository metadata: queue message repository.created_at is required (>0 unix time), repository=%s", repo.GetFullName())
 	}
 	if repo.PushedAt == nil {
-		return fmt.Errorf("invalid repository metadata: pushed_at is required, repository=%s", repo.GetFullName())
+		return fmt.Errorf("invalid repository metadata: queue message repository.pushed_at is required (>0 unix time), repository=%s", repo.GetFullName())
 	}
 	if repo.HTMLURL == nil || *repo.HTMLURL == "" {
 		return fmt.Errorf("invalid repository metadata: html_url is required, repository=%s", repo.GetFullName())

--- a/pkg/gitleaks/repository_validation.go
+++ b/pkg/gitleaks/repository_validation.go
@@ -1,0 +1,44 @@
+package gitleaks
+
+import (
+	"fmt"
+
+	"github.com/google/go-github/v44/github"
+)
+
+func validateRepositoriesForFilter(repos []*github.Repository) error {
+	for _, r := range repos {
+		if r == nil {
+			return fmt.Errorf("invalid repository metadata: repository is nil")
+		}
+		if r.Name == nil || *r.Name == "" {
+			return fmt.Errorf("invalid repository metadata: name is required")
+		}
+		if r.FullName == nil || *r.FullName == "" {
+			return fmt.Errorf("invalid repository metadata: full_name is required")
+		}
+		if r.Visibility == nil || *r.Visibility == "" {
+			return fmt.Errorf("invalid repository metadata: visibility is required, repository=%s", r.GetFullName())
+		}
+	}
+	return nil
+}
+
+func validateRepositoryForScan(repo *github.Repository) error {
+	if repo == nil {
+		return fmt.Errorf("invalid repository metadata: repository is nil")
+	}
+	if repo.CloneURL == nil || *repo.CloneURL == "" {
+		return fmt.Errorf("invalid repository metadata: clone_url is required, repository=%s", repo.GetFullName())
+	}
+	if repo.CreatedAt == nil {
+		return fmt.Errorf("invalid repository metadata: created_at is required, repository=%s", repo.GetFullName())
+	}
+	if repo.PushedAt == nil {
+		return fmt.Errorf("invalid repository metadata: pushed_at is required, repository=%s", repo.GetFullName())
+	}
+	if repo.HTMLURL == nil || *repo.HTMLURL == "" {
+		return fmt.Errorf("invalid repository metadata: html_url is required, repository=%s", repo.GetFullName())
+	}
+	return nil
+}


### PR DESCRIPTION
- [こちら](https://github.com/orgs/ca-risken/projects/4/views/1?pane=issue&itemId=154013276&issue=ca-risken%7Cinternal-community%7C930)のissueに関するPRです
- スキャンの際、datasource-apiから送られてきたCodeQueueMessageの中のリポジトリメタデータを使用するよう変更
- 以下datasource-apiにおけるメッセージの内容
https://github.com/ca-risken/datasource-api/blob/3a8f1da0d63c6a485723f492ea891e05b4831826/pkg/message/code.go#L33
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ca-risken/code/pull/188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
