### PR TITLE
[add]dependency-parents-status-update-function

### DIFF
--- a/pkg/dependency/handler.go
+++ b/pkg/dependency/handler.go
@@ -180,6 +180,30 @@ func (s *sqsHandler) updateRepositoryStatusErrorWithWarn(ctx context.Context, pr
 	}
 }
 
+func (s *sqsHandler) updateDependencySettingStatusError(ctx context.Context, gitHubSetting *code.GitHubSetting, statusDetail string) error {
+	if gitHubSetting == nil || gitHubSetting.DependencySetting == nil {
+		return fmt.Errorf("dependency setting is required")
+	}
+	resp, err := s.codeClient.PutDependencySetting(ctx, &code.PutDependencySettingRequest{
+		ProjectId: gitHubSetting.DependencySetting.ProjectId,
+		DependencySetting: &code.DependencySettingForUpsert{
+			GithubSettingId:   gitHubSetting.DependencySetting.GithubSettingId,
+			CodeDataSourceId:  gitHubSetting.DependencySetting.CodeDataSourceId,
+			ProjectId:         gitHubSetting.DependencySetting.ProjectId,
+			RepositoryPattern: gitHubSetting.DependencySetting.RepositoryPattern,
+			Status:            code.Status_ERROR,
+			StatusDetail:      sanitizeStatusDetail(code.Status_ERROR, statusDetail),
+			ScanAt:            time.Now().Unix(),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	s.logger.Infof(ctx, "Success to update dependency setting status, github_setting_id=%d, status=%v, response=%+v",
+		gitHubSetting.DependencySetting.GithubSettingId, code.Status_ERROR, resp)
+	return nil
+}
+
 func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, requestID string) error {
 	repos, err := s.githubClient.ListRepository(ctx, gitHubSetting, msg.RepositoryName)
 	if err != nil {

--- a/pkg/dependency/handler.go
+++ b/pkg/dependency/handler.go
@@ -143,67 +143,6 @@ func (s *sqsHandler) analyzeAlert(ctx context.Context, projectID uint32) error {
 	return err
 }
 
-func (s *sqsHandler) updateRepositoryStatusInProgress(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName string) error {
-	return s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_IN_PROGRESS, "")
-}
-
-func (s *sqsHandler) updateRepositoryStatusError(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName, statusDetail string) error {
-	return s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_ERROR, statusDetail)
-}
-
-func (s *sqsHandler) updateRepositoryStatusSuccess(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName string) error {
-	return s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_OK, "")
-}
-
-func (s *sqsHandler) updateRepositoryStatus(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName string, status code.Status, statusDetail string) error {
-	resp, err := s.codeClient.PutDependencyRepository(ctx, &code.PutDependencyRepositoryRequest{
-		ProjectId: projectID,
-		DependencyRepository: &code.DependencyRepositoryForUpsert{
-			GithubSettingId:    githubSettingID,
-			RepositoryFullName: repositoryFullName,
-			Status:             status,
-			StatusDetail:       sanitizeStatusDetail(status, statusDetail),
-			ScanAt:             time.Now().Unix(),
-		},
-	})
-	if err != nil {
-		return err
-	}
-	s.logger.Infof(ctx, "Success to update repository scan status, repository=%s, status=%v, response=%+v", repositoryFullName, status, resp)
-	return nil
-}
-
-// updateRepositoryStatusErrorWithWarn updates repository status to ERROR and logs a warning if the update fails
-func (s *sqsHandler) updateRepositoryStatusErrorWithWarn(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName, statusDetail string) {
-	if err := s.updateRepositoryStatusError(ctx, projectID, githubSettingID, repositoryFullName, statusDetail); err != nil {
-		s.logger.Warnf(ctx, "Failed to update repository status error: repository_name=%s, err=%+v", repositoryFullName, err)
-	}
-}
-
-func (s *sqsHandler) updateDependencySettingStatusError(ctx context.Context, gitHubSetting *code.GitHubSetting, statusDetail string) error {
-	if gitHubSetting == nil || gitHubSetting.DependencySetting == nil {
-		return fmt.Errorf("dependency setting is required")
-	}
-	resp, err := s.codeClient.PutDependencySetting(ctx, &code.PutDependencySettingRequest{
-		ProjectId: gitHubSetting.DependencySetting.ProjectId,
-		DependencySetting: &code.DependencySettingForUpsert{
-			GithubSettingId:   gitHubSetting.DependencySetting.GithubSettingId,
-			CodeDataSourceId:  gitHubSetting.DependencySetting.CodeDataSourceId,
-			ProjectId:         gitHubSetting.DependencySetting.ProjectId,
-			RepositoryPattern: gitHubSetting.DependencySetting.RepositoryPattern,
-			Status:            code.Status_ERROR,
-			StatusDetail:      sanitizeStatusDetail(code.Status_ERROR, statusDetail),
-			ScanAt:            time.Now().Unix(),
-		},
-	})
-	if err != nil {
-		return err
-	}
-	s.logger.Infof(ctx, "Success to update dependency setting status, github_setting_id=%d, status=%v, response=%+v",
-		gitHubSetting.DependencySetting.GithubSettingId, code.Status_ERROR, resp)
-	return nil
-}
-
 func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, requestID string) error {
 	repos, err := s.githubClient.ListRepository(ctx, gitHubSetting, msg.RepositoryName)
 	if err != nil {
@@ -328,4 +267,65 @@ func sanitizeStatusDetail(status code.Status, statusDetail string) string {
 	statusDetail = common.CutString(statusDetail, 200)
 	// Re-sanitize after CutString to prevent invalid UTF-8 from byte-level truncation
 	return strings.ToValidUTF8(statusDetail, "")
+}
+
+func (s *sqsHandler) updateRepositoryStatusInProgress(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName string) error {
+	return s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_IN_PROGRESS, "")
+}
+
+func (s *sqsHandler) updateRepositoryStatusError(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName, statusDetail string) error {
+	return s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_ERROR, statusDetail)
+}
+
+func (s *sqsHandler) updateRepositoryStatusSuccess(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName string) error {
+	return s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_OK, "")
+}
+
+func (s *sqsHandler) updateRepositoryStatus(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName string, status code.Status, statusDetail string) error {
+	resp, err := s.codeClient.PutDependencyRepository(ctx, &code.PutDependencyRepositoryRequest{
+		ProjectId: projectID,
+		DependencyRepository: &code.DependencyRepositoryForUpsert{
+			GithubSettingId:    githubSettingID,
+			RepositoryFullName: repositoryFullName,
+			Status:             status,
+			StatusDetail:       sanitizeStatusDetail(status, statusDetail),
+			ScanAt:             time.Now().Unix(),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	s.logger.Infof(ctx, "Success to update repository scan status, repository=%s, status=%v, response=%+v", repositoryFullName, status, resp)
+	return nil
+}
+
+// updateRepositoryStatusErrorWithWarn updates repository status to ERROR and logs a warning if the update fails
+func (s *sqsHandler) updateRepositoryStatusErrorWithWarn(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName, statusDetail string) {
+	if err := s.updateRepositoryStatusError(ctx, projectID, githubSettingID, repositoryFullName, statusDetail); err != nil {
+		s.logger.Warnf(ctx, "Failed to update repository status error: repository_name=%s, err=%+v", repositoryFullName, err)
+	}
+}
+
+func (s *sqsHandler) updateDependencySettingStatusError(ctx context.Context, gitHubSetting *code.GitHubSetting, statusDetail string) error {
+	if gitHubSetting == nil || gitHubSetting.DependencySetting == nil {
+		return fmt.Errorf("dependency setting is required")
+	}
+	resp, err := s.codeClient.PutDependencySetting(ctx, &code.PutDependencySettingRequest{
+		ProjectId: gitHubSetting.DependencySetting.ProjectId,
+		DependencySetting: &code.DependencySettingForUpsert{
+			GithubSettingId:   gitHubSetting.DependencySetting.GithubSettingId,
+			CodeDataSourceId:  gitHubSetting.DependencySetting.CodeDataSourceId,
+			ProjectId:         gitHubSetting.DependencySetting.ProjectId,
+			RepositoryPattern: gitHubSetting.DependencySetting.RepositoryPattern,
+			Status:            code.Status_ERROR,
+			StatusDetail:      sanitizeStatusDetail(code.Status_ERROR, statusDetail),
+			ScanAt:            time.Now().Unix(),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	s.logger.Infof(ctx, "Success to update dependency setting status, github_setting_id=%d, status=%v, response=%+v",
+		gitHubSetting.DependencySetting.GithubSettingId, code.Status_ERROR, resp)
+	return nil
 }

--- a/pkg/dependency/handler_test.go
+++ b/pkg/dependency/handler_test.go
@@ -1,0 +1,50 @@
+package dependency
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ca-risken/common/pkg/logging"
+	"github.com/ca-risken/datasource-api/proto/code"
+	"github.com/ca-risken/datasource-api/proto/code/mocks"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestUpdateDependencySettingStatusError(t *testing.T) {
+	ctx := context.Background()
+	mockCode := mocks.CodeServiceClient{}
+	mockCode.
+		On("PutDependencySetting", mock.Anything, mock.MatchedBy(func(req *code.PutDependencySettingRequest) bool {
+			if req == nil || req.DependencySetting == nil {
+				return false
+			}
+			return req.ProjectId == 1 &&
+				req.DependencySetting.GithubSettingId == 2 &&
+				req.DependencySetting.CodeDataSourceId == 3 &&
+				req.DependencySetting.ProjectId == 1 &&
+				req.DependencySetting.RepositoryPattern == "owner/*" &&
+				req.DependencySetting.Status == code.Status_ERROR &&
+				req.DependencySetting.StatusDetail == "scan failed" &&
+				req.DependencySetting.ScanAt > 0
+		}), mock.Anything).
+		Return(&code.PutDependencySettingResponse{DependencySetting: &code.DependencySetting{}}, nil).
+		Once()
+
+	s := sqsHandler{
+		codeClient: &mockCode,
+		logger:     logging.NewLogger(),
+	}
+	err := s.updateDependencySettingStatusError(ctx, &code.GitHubSetting{
+		DependencySetting: &code.DependencySetting{
+			ProjectId:         1,
+			GithubSettingId:   2,
+			CodeDataSourceId:  3,
+			RepositoryPattern: "owner/*",
+		},
+	}, "scan failed")
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+
+	mockCode.AssertExpectations(t)
+}


### PR DESCRIPTION
- 親ステータスを直接Errorにするためのヘルパー関数追加(`updateDependencySettingStatusError`)
- ステータス更新系処理の位置を変更(可読性向上のため)