### PR TITLE
[add]ghapp-mode

### DIFF
--- a/cmd/codescan/main.go
+++ b/cmd/codescan/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ca-risken/code/pkg/codescan"
+	githubcli "github.com/ca-risken/code/pkg/github"
 	"github.com/ca-risken/code/pkg/grpc"
 	"github.com/ca-risken/code/pkg/sqs"
 	"github.com/ca-risken/common/pkg/logging"
@@ -46,7 +47,10 @@ type AppConfig struct {
 	WaitTimeSecond        int32  `split_words:"true" default:"20"`
 
 	// codescan
-	GithubDefaultToken string `required:"true" split_words:"true" default:"your-token-here"`
+	GithubDefaultToken           string   `required:"true" split_words:"true" default:"your-token-here"`
+	GithubAppID                  string   `split_words:"true"`
+	GithubAppPrivateKey          string   `split_words:"true"`
+	GithubAppAllowedBaseURLHosts []string `split_words:"true"`
 
 	// scan settings
 	LimitRepositorySizeKb int `required:"true" split_words:"true" default:"500000"` // 500MB
@@ -115,6 +119,11 @@ func main() {
 		cc,
 		conf.CodeDataKey,
 		conf.GithubDefaultToken,
+		&githubcli.AppAuthConfig{
+			AppID:               conf.GithubAppID,
+			PrivateKey:          conf.GithubAppPrivateKey,
+			AllowedBaseURLHosts: conf.GithubAppAllowedBaseURLHosts,
+		},
 		conf.LimitRepositorySizeKb,
 		appLogger,
 	)

--- a/cmd/dependency/main.go
+++ b/cmd/dependency/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ca-risken/code/pkg/dependency"
+	githubcli "github.com/ca-risken/code/pkg/github"
 	"github.com/ca-risken/code/pkg/grpc"
 	"github.com/ca-risken/code/pkg/sqs"
 	"github.com/ca-risken/common/pkg/logging"
@@ -49,7 +50,10 @@ type AppConfig struct {
 	WaitTimeSecond          int32  `split_words:"true" default:"20"`
 
 	// dependency
-	TrivyPath string `split_words:"true" default:"/usr/local/bin/trivy"`
+	TrivyPath                    string   `split_words:"true" default:"/usr/local/bin/trivy"`
+	GithubAppID                  string   `split_words:"true"`
+	GithubAppPrivateKey          string   `split_words:"true"`
+	GithubAppAllowedBaseURLHosts []string `split_words:"true"`
 
 	// scan settings
 	LimitRepositorySizeKb int `required:"true" split_words:"true" default:"500000"` // 500MB
@@ -129,6 +133,11 @@ func main() {
 		cc,
 		vc,
 		conf.CodeDataKey,
+		&githubcli.AppAuthConfig{
+			AppID:               conf.GithubAppID,
+			PrivateKey:          conf.GithubAppPrivateKey,
+			AllowedBaseURLHosts: conf.GithubAppAllowedBaseURLHosts,
+		},
 		conf.TrivyPath,
 		conf.LimitRepositorySizeKb,
 		appLogger,

--- a/cmd/dependency/main.go
+++ b/cmd/dependency/main.go
@@ -51,6 +51,7 @@ type AppConfig struct {
 
 	// dependency
 	TrivyPath                    string   `split_words:"true" default:"/usr/local/bin/trivy"`
+	GithubDefaultToken           string   `required:"true" split_words:"true" default:"your-token-here"`
 	GithubAppID                  string   `split_words:"true"`
 	GithubAppPrivateKey          string   `split_words:"true"`
 	GithubAppAllowedBaseURLHosts []string `split_words:"true"`
@@ -133,6 +134,7 @@ func main() {
 		cc,
 		vc,
 		conf.CodeDataKey,
+		conf.GithubDefaultToken,
 		&githubcli.AppAuthConfig{
 			AppID:               conf.GithubAppID,
 			PrivateKey:          conf.GithubAppPrivateKey,

--- a/cmd/gitleaks/main.go
+++ b/cmd/gitleaks/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	githubcli "github.com/ca-risken/code/pkg/github"
 	"github.com/ca-risken/code/pkg/gitleaks"
 	"github.com/ca-risken/code/pkg/grpc"
 	"github.com/ca-risken/code/pkg/sqs"
@@ -48,9 +49,12 @@ type AppConfig struct {
 	WaitTimeSecond        int32  `split_words:"true" default:"20"`
 
 	// gitleaks
-	GithubDefaultToken string `required:"true" split_words:"true" default:"your-token-here"`
-	Redact             bool   `split_words:"true" default:"true"`
-	GitleaksConfigPath string `split_words:"true"`
+	GithubDefaultToken           string   `required:"true" split_words:"true" default:"your-token-here"`
+	GithubAppID                  string   `split_words:"true"`
+	GithubAppPrivateKey          string   `split_words:"true"`
+	GithubAppAllowedBaseURLHosts []string `split_words:"true"`
+	Redact                       bool     `split_words:"true" default:"true"`
+	GitleaksConfigPath           string   `split_words:"true"`
 
 	// scan settings
 	LimitRepositorySizeKb int `required:"true" split_words:"true" default:"500000"` // 500MB
@@ -119,6 +123,11 @@ func main() {
 		cc,
 		conf.CodeDataKey,
 		conf.GithubDefaultToken,
+		&githubcli.AppAuthConfig{
+			AppID:               conf.GithubAppID,
+			PrivateKey:          conf.GithubAppPrivateKey,
+			AllowedBaseURLHosts: conf.GithubAppAllowedBaseURLHosts,
+		},
 		conf.Redact,
 		conf.GitleaksConfigPath,
 		conf.LimitRepositorySizeKb,

--- a/pkg/codescan/handler.go
+++ b/pkg/codescan/handler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/ca-risken/code/pkg/common"
-	codecrypto "github.com/ca-risken/code/pkg/crypto"
 	githubcli "github.com/ca-risken/code/pkg/github"
 	"github.com/ca-risken/common/pkg/logging"
 	mimosasqs "github.com/ca-risken/common/pkg/sqs"
@@ -77,7 +76,7 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 		s.logger.Errorf(ctx, "Failed to get scan setting: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
 		return mimosasqs.WrapNonRetryable(err)
 	}
-	token, err := s.decryptPersonalAccessToken(gitHubSetting)
+	token, err := common.DecryptGitHubPersonalAccessToken(&s.cipherBlock, gitHubSetting)
 	if err != nil {
 		s.logger.Errorf(ctx, "Failed to decrypt personal access token: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
 		return mimosasqs.WrapNonRetryable(err)
@@ -85,13 +84,6 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 	gitHubSetting.PersonalAccessToken = token // Set the plaintext so that the value is still decipherable next processes.
 
 	return s.handleRepositoryScan(ctx, msg, gitHubSetting, token)
-}
-
-func (s *sqsHandler) decryptPersonalAccessToken(gitHubSetting *code.GitHubSetting) (string, error) {
-	if gitHubSetting == nil || gitHubSetting.AuthMode == code.GitHubAuthModeGitHubApp {
-		return "", nil
-	}
-	return codecrypto.DecryptWithBase64(&s.cipherBlock, gitHubSetting.PersonalAccessToken)
 }
 
 func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string) error {

--- a/pkg/codescan/handler.go
+++ b/pkg/codescan/handler.go
@@ -39,6 +39,7 @@ func NewHandler(
 	cc code.CodeServiceClient,
 	codeDataKey string,
 	githubDefaultToken string,
+	appAuth *githubcli.AppAuthConfig,
 	limitRepositorySizeKb int,
 	l logging.Logger,
 ) (*sqsHandler, error) {
@@ -47,9 +48,13 @@ func NewHandler(
 	if err != nil {
 		return nil, err
 	}
+	githubClient, err := githubcli.NewGithubClientWithAppAuth(githubDefaultToken, appAuth, l)
+	if err != nil {
+		return nil, err
+	}
 	return &sqsHandler{
 		cipherBlock:           block,
-		githubClient:          githubcli.NewGithubClient(githubDefaultToken, l),
+		githubClient:          githubClient,
 		findingClient:         fc,
 		alertClient:           ac,
 		codeClient:            cc,
@@ -72,7 +77,7 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 		s.logger.Errorf(ctx, "Failed to get scan setting: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
 		return mimosasqs.WrapNonRetryable(err)
 	}
-	token, err := codecrypto.DecryptWithBase64(&s.cipherBlock, gitHubSetting.PersonalAccessToken)
+	token, err := s.decryptPersonalAccessToken(gitHubSetting)
 	if err != nil {
 		s.logger.Errorf(ctx, "Failed to decrypt personal access token: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
 		return mimosasqs.WrapNonRetryable(err)
@@ -82,7 +87,14 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 	return s.handleRepositoryScan(ctx, msg, gitHubSetting, token)
 }
 
-func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, token string) error {
+func (s *sqsHandler) decryptPersonalAccessToken(gitHubSetting *code.GitHubSetting) (string, error) {
+	if gitHubSetting == nil || gitHubSetting.AuthMode == code.GitHubAuthModeGitHubApp {
+		return "", nil
+	}
+	return codecrypto.DecryptWithBase64(&s.cipherBlock, gitHubSetting.PersonalAccessToken)
+}
+
+func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string) error {
 	repos := common.GetRepositoriesFromCodeQueueMessage(msg)
 	if len(repos) == 0 {
 		err := fmt.Errorf("repository metadata is required in queue message")
@@ -101,14 +113,14 @@ func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.Code
 	repos = common.FilterByNamePattern(repos, gitHubSetting.CodeScanSetting.RepositoryPattern)
 
 	// Orchestrate repository scanning process
-	return s.orchestrateScanningProcess(ctx, msg, gitHubSetting, token, repos)
+	return s.orchestrateScanningProcess(ctx, msg, gitHubSetting, personalAccessToken, repos)
 }
 
-func (s *sqsHandler) orchestrateScanningProcess(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, token string, repos []*github.Repository) error {
+func (s *sqsHandler) orchestrateScanningProcess(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, repos []*github.Repository) error {
 	beforeScanAt := time.Now()
 
 	// Step 1: Scan all repositories
-	semgrepFindings, successfullyScannedRepos, err := s.scanAllRepositories(ctx, msg, gitHubSetting, token, repos)
+	semgrepFindings, successfullyScannedRepos, err := s.scanAllRepositories(ctx, msg, gitHubSetting, personalAccessToken, repos)
 	if err != nil {
 		return err
 	}
@@ -127,7 +139,7 @@ func (s *sqsHandler) orchestrateScanningProcess(ctx context.Context, msg *messag
 }
 
 // scanAllRepositories scans all repositories and returns findings and successfully scanned repository names
-func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, token string, repos []*github.Repository) ([]*SemgrepFinding, []string, error) {
+func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, repos []*github.Repository) ([]*SemgrepFinding, []string, error) {
 	semgrepFindings := []*SemgrepFinding{}
 	successfullyScannedRepos := []string{}
 
@@ -147,6 +159,12 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 		}
 
 		repoFullName := r.GetFullName()
+		token, err := s.githubClient.ResolveAccessToken(ctx, gitHubSetting, repoFullName, personalAccessToken)
+		if err != nil {
+			s.logger.Errorf(ctx, "Failed to resolve GitHub access token: github_setting_id=%d, repository_name=%s, err=%+v", msg.GitHubSettingID, repoFullName, err)
+			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
+			continue
+		}
 
 		// Update repository status to IN_PROGRESS
 		if err := s.updateRepositoryStatusInProgress(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName); err != nil {

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -1,11 +1,14 @@
 package common
 
 import (
+	"crypto/cipher"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
 
+	codecrypto "github.com/ca-risken/code/pkg/crypto"
+	"github.com/ca-risken/datasource-api/proto/code"
 	"github.com/google/go-github/v44/github"
 )
 
@@ -60,4 +63,11 @@ func CreateCloneDir(repoName string) (string, error) {
 	}
 
 	return dir, nil
+}
+
+func DecryptGitHubPersonalAccessToken(block *cipher.Block, gitHubSetting *code.GitHubSetting) (string, error) {
+	if gitHubSetting == nil || gitHubSetting.AuthMode == code.GitHubAuthModeGitHubApp || gitHubSetting.PersonalAccessToken == "" {
+		return "", nil
+	}
+	return codecrypto.DecryptWithBase64(block, gitHubSetting.PersonalAccessToken)
 }

--- a/pkg/common/util_test.go
+++ b/pkg/common/util_test.go
@@ -1,10 +1,12 @@
 package common
 
 import (
+	"crypto/aes"
 	"os"
 	"reflect"
 	"testing"
 
+	"github.com/ca-risken/datasource-api/proto/code"
 	"github.com/google/go-github/v44/github"
 )
 
@@ -297,6 +299,66 @@ func TestCreateCloneDir(t *testing.T) {
 			}
 			if err == nil {
 				os.RemoveAll(dir)
+			}
+		})
+	}
+}
+
+func TestDecryptGitHubPersonalAccessToken(t *testing.T) {
+	block, err := aes.NewCipher([]byte("12345678901234567890123456789012"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name          string
+		gitHubSetting *code.GitHubSetting
+		want          string
+		wantErr       bool
+	}{
+		{
+			name: "nil setting returns empty token",
+			want: "",
+		},
+		{
+			name: "github app mode ignores personal access token",
+			gitHubSetting: &code.GitHubSetting{
+				AuthMode:            code.GitHubAuthModeGitHubApp,
+				PersonalAccessToken: "encrypted-token",
+			},
+			want: "",
+		},
+		{
+			name: "empty personal access token returns empty token",
+			gitHubSetting: &code.GitHubSetting{
+				AuthMode: code.GitHubAuthModePersonalAccessToken,
+			},
+			want: "",
+		},
+		{
+			name: "invalid encrypted token returns error",
+			gitHubSetting: &code.GitHubSetting{
+				AuthMode:            code.GitHubAuthModePersonalAccessToken,
+				PersonalAccessToken: "not base64",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DecryptGitHubPersonalAccessToken(&block, tt.gitHubSetting)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/pkg/dependency/handler.go
+++ b/pkg/dependency/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/ca-risken/code/pkg/common"
 	codecrypto "github.com/ca-risken/code/pkg/crypto"
+	githubcli "github.com/ca-risken/code/pkg/github"
 	"github.com/ca-risken/common/pkg/logging"
 	mimosasqs "github.com/ca-risken/common/pkg/sqs"
 	"github.com/ca-risken/core/proto/alert"
@@ -25,6 +26,7 @@ import (
 type sqsHandler struct {
 	cipherBlock           cipher.Block
 	dependencyClient      dependencyServiceClient
+	githubClient          githubcli.GithubServiceClient
 	findingClient         finding.FindingServiceClient
 	alertClient           alert.AlertServiceClient
 	codeClient            code.CodeServiceClient
@@ -40,6 +42,7 @@ func NewHandler(
 	cc code.CodeServiceClient,
 	vulnClient *vulnsdk.Client,
 	codeDataKey string,
+	appAuth *githubcli.AppAuthConfig,
 	trivyPath string,
 	limitRepositorySizeKb int,
 	l logging.Logger,
@@ -52,9 +55,14 @@ func NewHandler(
 	dependencyConf := &dependencyConfig{
 		trivyPath: trivyPath,
 	}
+	githubClient, err := githubcli.NewGithubClientWithAppAuth("", appAuth, l)
+	if err != nil {
+		return nil, err
+	}
 	return &sqsHandler{
 		cipherBlock:           block,
 		dependencyClient:      newDependencyClient(dependencyConf, l),
+		githubClient:          githubClient,
 		findingClient:         fc,
 		alertClient:           ac,
 		codeClient:            cc,
@@ -121,7 +129,7 @@ func (s *sqsHandler) getGitHubSetting(ctx context.Context, projectID, GitHubSett
 	if data == nil || data.GithubSetting == nil || data.GithubSetting.DependencySetting == nil {
 		return nil, fmt.Errorf("no data for dependency scan, project_id=%d, github_setting_id=%d", projectID, GitHubSettingID)
 	}
-	if data.GithubSetting.PersonalAccessToken == "" {
+	if data.GithubSetting.AuthMode == code.GitHubAuthModeGitHubApp || data.GithubSetting.PersonalAccessToken == "" {
 		return data.GithubSetting, nil
 	}
 	token, err := codecrypto.DecryptWithBase64(&s.cipherBlock, data.GithubSetting.PersonalAccessToken)
@@ -203,9 +211,15 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 
 func (s *sqsHandler) scanRepository(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, beforeScanAt time.Time, r *github.Repository) error {
 	repoFullName := r.GetFullName()
+	token, err := s.githubClient.ResolveAccessToken(ctx, gitHubSetting, repoFullName, gitHubSetting.PersonalAccessToken)
+	if err != nil {
+		s.logger.Errorf(ctx, "Failed to resolve GitHub access token: github_setting_id=%d, repository_name=%s, err=%+v", msg.GitHubSettingID, repoFullName, err)
+		s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
+		return mimosasqs.WrapNonRetryable(err)
+	}
 
 	resultFilePath := fmt.Sprintf("/tmp/%v_%v_%s_%v.json", msg.ProjectID, msg.GitHubSettingID, *r.Name, time.Now().Unix())
-	result, err := s.dependencyClient.getResult(ctx, *r.CloneURL, gitHubSetting.PersonalAccessToken, resultFilePath)
+	result, err := s.dependencyClient.getResult(ctx, *r.CloneURL, token, resultFilePath)
 	if err != nil {
 		s.logger.Errorf(ctx, "Failed to scan repositories: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
 		s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())

--- a/pkg/dependency/handler.go
+++ b/pkg/dependency/handler.go
@@ -207,7 +207,7 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 		}
 
 		if err := s.scanRepository(ctx, msg, gitHubSetting, beforeScanAt, r, token); err != nil {
-			continue
+			return successfullyScannedRepos, err
 		}
 		successfullyScannedRepos = append(successfullyScannedRepos, repoFullName)
 	}

--- a/pkg/dependency/handler.go
+++ b/pkg/dependency/handler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/ca-risken/code/pkg/common"
-	codecrypto "github.com/ca-risken/code/pkg/crypto"
 	githubcli "github.com/ca-risken/code/pkg/github"
 	"github.com/ca-risken/common/pkg/logging"
 	mimosasqs "github.com/ca-risken/common/pkg/sqs"
@@ -130,10 +129,7 @@ func (s *sqsHandler) getGitHubSetting(ctx context.Context, projectID, GitHubSett
 	if data == nil || data.GithubSetting == nil || data.GithubSetting.DependencySetting == nil {
 		return nil, fmt.Errorf("no data for dependency scan, project_id=%d, github_setting_id=%d", projectID, GitHubSettingID)
 	}
-	if data.GithubSetting.AuthMode == code.GitHubAuthModeGitHubApp || data.GithubSetting.PersonalAccessToken == "" {
-		return data.GithubSetting, nil
-	}
-	token, err := codecrypto.DecryptWithBase64(&s.cipherBlock, data.GithubSetting.PersonalAccessToken)
+	token, err := common.DecryptGitHubPersonalAccessToken(&s.cipherBlock, data.GithubSetting)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dependency/handler.go
+++ b/pkg/dependency/handler.go
@@ -42,6 +42,7 @@ func NewHandler(
 	cc code.CodeServiceClient,
 	vulnClient *vulnsdk.Client,
 	codeDataKey string,
+	githubDefaultToken string,
 	appAuth *githubcli.AppAuthConfig,
 	trivyPath string,
 	limitRepositorySizeKb int,
@@ -55,7 +56,7 @@ func NewHandler(
 	dependencyConf := &dependencyConfig{
 		trivyPath: trivyPath,
 	}
-	githubClient, err := githubcli.NewGithubClientWithAppAuth("", appAuth, l)
+	githubClient, err := githubcli.NewGithubClientWithAppAuth(githubDefaultToken, appAuth, l)
 	if err != nil {
 		return nil, err
 	}
@@ -197,11 +198,18 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 		}
 		repoFullName := r.GetFullName()
 
+		token, err := s.githubClient.ResolveAccessToken(ctx, gitHubSetting, repoFullName, gitHubSetting.PersonalAccessToken)
+		if err != nil {
+			s.logger.Errorf(ctx, "Failed to resolve GitHub access token: github_setting_id=%d, repository_name=%s, err=%+v", msg.GitHubSettingID, repoFullName, err)
+			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
+			continue
+		}
+
 		if err := s.updateRepositoryStatusInProgress(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName); err != nil {
 			s.logger.Warnf(ctx, "Failed to update repository status to IN_PROGRESS: repository_name=%s, err=%+v", repoFullName, err)
 		}
 
-		if err := s.scanRepository(ctx, msg, gitHubSetting, beforeScanAt, r); err != nil {
+		if err := s.scanRepository(ctx, msg, gitHubSetting, beforeScanAt, r, token); err != nil {
 			return successfullyScannedRepos, err
 		}
 		successfullyScannedRepos = append(successfullyScannedRepos, repoFullName)
@@ -209,15 +217,8 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 	return successfullyScannedRepos, nil
 }
 
-func (s *sqsHandler) scanRepository(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, beforeScanAt time.Time, r *github.Repository) error {
+func (s *sqsHandler) scanRepository(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, beforeScanAt time.Time, r *github.Repository, token string) error {
 	repoFullName := r.GetFullName()
-	token, err := s.githubClient.ResolveAccessToken(ctx, gitHubSetting, repoFullName, gitHubSetting.PersonalAccessToken)
-	if err != nil {
-		s.logger.Errorf(ctx, "Failed to resolve GitHub access token: github_setting_id=%d, repository_name=%s, err=%+v", msg.GitHubSettingID, repoFullName, err)
-		s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
-		return mimosasqs.WrapNonRetryable(err)
-	}
-
 	resultFilePath := fmt.Sprintf("/tmp/%v_%v_%s_%v.json", msg.ProjectID, msg.GitHubSettingID, *r.Name, time.Now().Unix())
 	result, err := s.dependencyClient.getResult(ctx, *r.CloneURL, token, resultFilePath)
 	if err != nil {

--- a/pkg/dependency/handler.go
+++ b/pkg/dependency/handler.go
@@ -92,8 +92,14 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 		s.logger.Errorf(ctx, "Failed to get scan setting: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
 		return mimosasqs.WrapNonRetryable(err)
 	}
+	token, err := common.DecryptGitHubPersonalAccessToken(&s.cipherBlock, gitHubSetting)
+	if err != nil {
+		s.logger.Errorf(ctx, "Failed to decrypt personal access token: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
+		return mimosasqs.WrapNonRetryable(err)
+	}
+	gitHubSetting.PersonalAccessToken = token // Set the plaintext so that the value is still decipherable next processes.
 
-	return s.handleRepositoryScan(ctx, msg, gitHubSetting, requestID)
+	return s.handleRepositoryScan(ctx, msg, gitHubSetting, token, requestID)
 }
 
 func (s *sqsHandler) skipScan(ctx context.Context, repo *github.Repository, limitRepositorySize int) bool {
@@ -129,11 +135,6 @@ func (s *sqsHandler) getGitHubSetting(ctx context.Context, projectID, GitHubSett
 	if data == nil || data.GithubSetting == nil || data.GithubSetting.DependencySetting == nil {
 		return nil, fmt.Errorf("no data for dependency scan, project_id=%d, github_setting_id=%d", projectID, GitHubSettingID)
 	}
-	token, err := common.DecryptGitHubPersonalAccessToken(&s.cipherBlock, data.GithubSetting)
-	if err != nil {
-		return nil, err
-	}
-	data.GithubSetting.PersonalAccessToken = token // Set the plaintext so that the value is still decipherable next processes.
 	return data.GithubSetting, nil
 }
 
@@ -144,7 +145,7 @@ func (s *sqsHandler) analyzeAlert(ctx context.Context, projectID uint32) error {
 	return err
 }
 
-func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, requestID string) error {
+func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, requestID string) error {
 	repos := common.GetRepositoriesFromCodeQueueMessage(msg)
 	if len(repos) == 0 {
 		err := fmt.Errorf("repository metadata is required in queue message")
@@ -159,14 +160,14 @@ func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.Code
 		requestID, len(repos), gitHubSetting.BaseUrl, gitHubSetting.TargetResource)
 	repos = common.FilterByNamePattern(repos, gitHubSetting.DependencySetting.RepositoryPattern)
 
-	return s.orchestrateScanningProcess(ctx, msg, gitHubSetting, repos, requestID)
+	return s.orchestrateScanningProcess(ctx, msg, gitHubSetting, personalAccessToken, repos, requestID)
 }
 
-func (s *sqsHandler) orchestrateScanningProcess(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, repos []*github.Repository, requestID string) error {
+func (s *sqsHandler) orchestrateScanningProcess(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, repos []*github.Repository, requestID string) error {
 	beforeScanAt := time.Now()
 
 	// Step 1: Scan repositories (includes per-repo find/put/clear)
-	successfullyScannedRepos, err := s.scanAllRepositories(ctx, msg, gitHubSetting, beforeScanAt, repos)
+	successfullyScannedRepos, err := s.scanAllRepositories(ctx, msg, gitHubSetting, personalAccessToken, beforeScanAt, repos)
 	if err != nil {
 		return err
 	}
@@ -176,7 +177,7 @@ func (s *sqsHandler) orchestrateScanningProcess(ctx context.Context, msg *messag
 }
 
 // scanAllRepositories scans all repositories and returns successfully scanned repository names
-func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, beforeScanAt time.Time, repos []*github.Repository) ([]string, error) {
+func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, beforeScanAt time.Time, repos []*github.Repository) ([]string, error) {
 	successfullyScannedRepos := []string{}
 	for _, r := range repos {
 		if err := common.ValidateRepository(r, gitHubSetting.BaseUrl); err != nil {
@@ -194,7 +195,7 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 		}
 		repoFullName := r.GetFullName()
 
-		token, err := s.githubClient.ResolveAccessToken(ctx, gitHubSetting, repoFullName, gitHubSetting.PersonalAccessToken)
+		token, err := s.githubClient.ResolveAccessToken(ctx, gitHubSetting, repoFullName, personalAccessToken)
 		if err != nil {
 			s.logger.Errorf(ctx, "Failed to resolve GitHub access token: github_setting_id=%d, repository_name=%s, err=%+v", msg.GitHubSettingID, repoFullName, err)
 			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
@@ -206,7 +207,7 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 		}
 
 		if err := s.scanRepository(ctx, msg, gitHubSetting, beforeScanAt, r, token); err != nil {
-			return successfullyScannedRepos, err
+			continue
 		}
 		successfullyScannedRepos = append(successfullyScannedRepos, repoFullName)
 	}

--- a/pkg/dependency/handler_test.go
+++ b/pkg/dependency/handler_test.go
@@ -134,6 +134,7 @@ func TestHandleRepositoryScan(t *testing.T) {
 					GithubSettingId:  2,
 					CodeDataSourceId: 3,
 				}},
+				"",
 				"req-1",
 			)
 			if tt.wantErr {
@@ -215,7 +216,7 @@ func TestScanAllRepositories(t *testing.T) {
 				},
 			}
 
-			_, err := s.scanAllRepositories(ctx, msg, setting, time.Now(), tt.repos)
+			_, err := s.scanAllRepositories(ctx, msg, setting, "", time.Now(), tt.repos)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -20,6 +20,7 @@ const RETRY_NUM uint64 = 3
 type GithubServiceClient interface {
 	Clone(ctx context.Context, token string, cloneURL string, dstDir string) error
 	SupportsGitHubApp() bool
+	ResolveAccessToken(ctx context.Context, config *code.GitHubSetting, repoName, personalAccessToken string) (string, error)
 	ResolveInstallationToken(ctx context.Context, config *code.GitHubSetting, repoName string) (string, error)
 }
 
@@ -91,6 +92,13 @@ func (g *riskenGitHubClient) Clone(ctx context.Context, token string, cloneURL s
 
 func (g *riskenGitHubClient) SupportsGitHubApp() bool {
 	return g.appAuth != nil && g.appAuth.Enabled()
+}
+
+func (g *riskenGitHubClient) ResolveAccessToken(ctx context.Context, config *code.GitHubSetting, repoName, personalAccessToken string) (string, error) {
+	if config != nil && config.AuthMode == code.GitHubAuthModeGitHubApp {
+		return g.ResolveInstallationToken(ctx, config, repoName)
+	}
+	return getToken(personalAccessToken, g.defaultToken), nil
 }
 
 func (g *riskenGitHubClient) ResolveInstallationToken(ctx context.Context, config *code.GitHubSetting, repoName string) (string, error) {

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -146,3 +146,57 @@ func TestResolveInstallationTokenError(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveAccessToken(t *testing.T) {
+	client := NewGithubClient("default-token", logging.NewLogger())
+	cases := []struct {
+		name     string
+		config   *code.GitHubSetting
+		patToken string
+		want     string
+	}{
+		{
+			name:     "personal access token",
+			config:   &code.GitHubSetting{AuthMode: code.GitHubAuthModePersonalAccessToken},
+			patToken: "pat-token",
+			want:     "pat-token",
+		},
+		{
+			name:   "default token fallback",
+			config: &code.GitHubSetting{AuthMode: code.GitHubAuthModePersonalAccessToken},
+			want:   "default-token",
+		},
+		{
+			name:     "empty auth mode keeps pat behavior",
+			config:   &code.GitHubSetting{},
+			patToken: "pat-token",
+			want:     "pat-token",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := client.ResolveAccessToken(context.Background(), c.config, "owner/repo", c.patToken)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Fatalf("Unexpected token: want=%s, got=%s", c.want, got)
+			}
+		})
+	}
+}
+
+func TestResolveAccessTokenGitHubAppRequiresAppAuth(t *testing.T) {
+	client := NewGithubClient("default-token", logging.NewLogger())
+	_, err := client.ResolveAccessToken(context.Background(), &code.GitHubSetting{
+		AuthMode:       code.GitHubAuthModeGitHubApp,
+		InstallationId: 12345,
+	}, "owner/repo", "pat-token")
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if err.Error() != "github app auth is not configured" {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -276,7 +276,7 @@ func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.Code
 		if err != nil {
 			s.logger.Errorf(ctx, "Failed to scan repositories: github_setting_id=%d, repository_full_name=%s, err=%+v", msg.GitHubSettingID, repoFullName, err)
 			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
-			return mimosasqs.WrapNonRetryable(err)
+			continue
 		}
 
 		// Put Resource

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -276,7 +276,7 @@ func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.Code
 		if err != nil {
 			s.logger.Errorf(ctx, "Failed to scan repositories: github_setting_id=%d, repository_full_name=%s, err=%+v", msg.GitHubSettingID, repoFullName, err)
 			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
-			continue
+			return err
 		}
 
 		// Put Resource

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -276,7 +276,7 @@ func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.Code
 		if err != nil {
 			s.logger.Errorf(ctx, "Failed to scan repositories: github_setting_id=%d, repository_full_name=%s, err=%+v", msg.GitHubSettingID, repoFullName, err)
 			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
-			return err
+			return mimosasqs.WrapNonRetryable(err)
 		}
 
 		// Put Resource

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -271,7 +271,7 @@ func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.Code
 		if err != nil {
 			s.logger.Errorf(ctx, "Failed to resolve GitHub access token: github_setting_id=%d, repository_full_name=%s, err=%+v", msg.GitHubSettingID, repoFullName, err)
 			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
-			return mimosasqs.WrapNonRetryable(err)
+			continue
 		}
 
 		// Update repository status to IN_PROGRESS

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -44,6 +44,7 @@ func NewHandler(
 	cc code.CodeServiceClient,
 	codeDataKey string,
 	githubDefaultToken string,
+	appAuth *githubcli.AppAuthConfig,
 	redact bool,
 	gitleaksConfigPath string,
 	limitRepositorySizeKb int,
@@ -59,9 +60,13 @@ func NewHandler(
 		redact:             redact,
 		configPath:         gitleaksConfigPath,
 	}
+	githubClient, err := githubcli.NewGithubClientWithAppAuth(githubDefaultToken, appAuth, l)
+	if err != nil {
+		return nil, err
+	}
 	return &sqsHandler{
 		cipherBlock:           block,
-		githubClient:          githubcli.NewGithubClient(githubDefaultToken, l),
+		githubClient:          githubClient,
 		gitleaksClient:        newGitleaksClient(gitleaksConf),
 		findingClient:         fc,
 		alertClient:           ac,
@@ -91,7 +96,7 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 		s.logger.Errorf(ctx, "Failed to get scan setting: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
 		return mimosasqs.WrapNonRetryable(err)
 	}
-	token, err := codecrypto.DecryptWithBase64(&s.cipherBlock, gitHubSetting.PersonalAccessToken)
+	token, err := s.decryptPersonalAccessToken(gitHubSetting)
 	if err != nil {
 		s.logger.Errorf(ctx, "Failed to decrypt personal access token: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
 		return mimosasqs.WrapNonRetryable(err)
@@ -112,6 +117,13 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 		return mimosasqs.WrapNonRetryable(err)
 	}
 	return nil
+}
+
+func (s *sqsHandler) decryptPersonalAccessToken(gitHubSetting *code.GitHubSetting) (string, error) {
+	if gitHubSetting == nil || gitHubSetting.AuthMode == code.GitHubAuthModeGitHubApp {
+		return "", nil
+	}
+	return codecrypto.DecryptWithBase64(&s.cipherBlock, gitHubSetting.PersonalAccessToken)
 }
 
 func (s *sqsHandler) skipScan(ctx context.Context, repo *github.Repository, lastScannedAt *time.Time, limitRepositorySize int) bool {
@@ -222,12 +234,12 @@ func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.Code
 	s.logger.Infof(ctx, "Got repositories from queue message, count=%d, baseURL=%s, target=%s",
 		len(repos), gitHubSetting.BaseUrl, gitHubSetting.TargetResource)
 
-	return s.scanDiffRepositories(ctx, msg, token, repos, gitHubSetting.BaseUrl)
+	return s.scanDiffRepositories(ctx, msg, gitHubSetting, token, repos)
 }
 
-func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.CodeQueueMessage, token string, repos []*github.Repository, githubBaseURL string) error {
+func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, repos []*github.Repository) error {
 	for _, r := range repos {
-		if err := common.ValidateRepository(r, githubBaseURL); err != nil {
+		if err := common.ValidateRepository(r, gitHubSetting.BaseUrl); err != nil {
 			repoFullName := ""
 			if r != nil {
 				repoFullName = r.GetFullName()
@@ -255,6 +267,12 @@ func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.Code
 		}
 
 		repoFullName := r.GetFullName()
+		token, err := s.githubClient.ResolveAccessToken(ctx, gitHubSetting, repoFullName, personalAccessToken)
+		if err != nil {
+			s.logger.Errorf(ctx, "Failed to resolve GitHub access token: github_setting_id=%d, repository_full_name=%s, err=%+v", msg.GitHubSettingID, repoFullName, err)
+			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
+			return mimosasqs.WrapNonRetryable(err)
+		}
 
 		// Update repository status to IN_PROGRESS
 		if err := s.updateRepositoryStatusInProgress(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName); err != nil {

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/ca-risken/code/pkg/common"
-	codecrypto "github.com/ca-risken/code/pkg/crypto"
 	githubcli "github.com/ca-risken/code/pkg/github"
 	"github.com/ca-risken/common/pkg/logging"
 	mimosasqs "github.com/ca-risken/common/pkg/sqs"
@@ -96,7 +95,7 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 		s.logger.Errorf(ctx, "Failed to get scan setting: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
 		return mimosasqs.WrapNonRetryable(err)
 	}
-	token, err := s.decryptPersonalAccessToken(gitHubSetting)
+	token, err := common.DecryptGitHubPersonalAccessToken(&s.cipherBlock, gitHubSetting)
 	if err != nil {
 		s.logger.Errorf(ctx, "Failed to decrypt personal access token: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
 		return mimosasqs.WrapNonRetryable(err)
@@ -117,13 +116,6 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 		return mimosasqs.WrapNonRetryable(err)
 	}
 	return nil
-}
-
-func (s *sqsHandler) decryptPersonalAccessToken(gitHubSetting *code.GitHubSetting) (string, error) {
-	if gitHubSetting == nil || gitHubSetting.AuthMode == code.GitHubAuthModeGitHubApp {
-		return "", nil
-	}
-	return codecrypto.DecryptWithBase64(&s.cipherBlock, gitHubSetting.PersonalAccessToken)
 }
 
 func (s *sqsHandler) skipScan(ctx context.Context, repo *github.Repository, lastScannedAt *time.Time, limitRepositorySize int) bool {


### PR DESCRIPTION
code 側で共通の ResolveAccessToken を追加し、各 worker が repository ごとに以下を切り替えるようにしました。
PAT/未指定: 復号済み PAT、なければ既存の default token
GITHUB_APP: repository full name を使って installation token を解決

主な変更:
- pkg/github/github.go : ResolveAccessToken 追加
- pkg/gitleaks/handler.go : gitleaks clone 前に token 解決
- pkg/dependency/handler.go : trivy scan 前に token 解決
- pkg/codescan/handler.go : semgrep clone 前に token 解決