### PR TITLE
fix: codescan の Semgrep を 1.170.0 に更新して MEDIUM severity 対応する

### DIFF
--- a/dockers/codescan/Dockerfile
+++ b/dockers/codescan/Dockerfile
@@ -8,7 +8,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o /go/bin/codescan cmd/co
 
 FROM public.ecr.aws/risken/base/risken-base:v0.0.1 AS riskenbase
 
-FROM returntocorp/semgrep:1.46.0
+FROM semgrep/semgrep:1.170.0
 COPY --from=builder /go/bin/codescan /usr/local/codescan/bin/
 COPY --from=riskenbase /usr/local/bin/env-injector /usr/local/bin/
 RUN apk add git

--- a/pkg/codescan/semgrep.go
+++ b/pkg/codescan/semgrep.go
@@ -106,27 +106,26 @@ func extractSemgrepMetadata(metadata any) *SemgrepMetadata {
 
 func GetScoreSemgrep(serverity, likelihood, impact string) float32 {
 	switch serverity {
-	case "WARNING":
+	case "CRITICAL":
+		return 0.9
+	case "MEDIUM", "WARNING":
 		return 0.3
-	case "INFO":
+	case "LOW", "INFO":
 		return 0.1
-	}
-	if serverity != "ERROR" {
+	case "HIGH", "ERROR":
+		if impact == "HIGH" && likelihood == "HIGH" {
+			return 0.8
+		} else if impact == "HIGH" {
+			return 0.6
+		} else if impact == "MEDIUM" {
+			return 0.5
+		} else if impact == "LOW" {
+			return 0.4
+		}
+		return 0.6
+	default:
 		return 0.0
 	}
-
-	// severity "ERROR"
-	// Fine-grained scoring
-	if impact == "HIGH" && likelihood == "HIGH" {
-		return 0.8
-	} else if impact == "HIGH" {
-		return 0.6
-	} else if impact == "MEDIUM" {
-		return 0.5
-	} else if impact == "LOW" {
-		return 0.4
-	}
-	return 0.6 // default ERROR score
 }
 
 func GenerateDataSourceIDForSemgrep(f *SemgrepFinding) string {

--- a/pkg/codescan/semgrep_test.go
+++ b/pkg/codescan/semgrep_test.go
@@ -128,6 +128,36 @@ func TestGetScoreSemgrep(t *testing.T) {
 			want: 0.1,
 		},
 		{
+			name: "CRITICAL",
+			input: &args{
+				serverity: "CRITICAL",
+			},
+			want: 0.9,
+		},
+		{
+			name: "HIGH(impact: HIGH, likelihood: HIGH)",
+			input: &args{
+				serverity:  "HIGH",
+				likelihood: "HIGH",
+				impact:     "HIGH",
+			},
+			want: 0.8,
+		},
+		{
+			name: "MEDIUM",
+			input: &args{
+				serverity: "MEDIUM",
+			},
+			want: 0.3,
+		},
+		{
+			name: "LOW",
+			input: &args{
+				serverity: "LOW",
+			},
+			want: 0.1,
+		},
+		{
 			name: "UNKNOWN",
 			input: &args{
 				serverity: "UNKNOWN",


### PR DESCRIPTION
## PRの概要

codescan が利用している Semgrep 1.46.0 では、現行の `p/default` ルールが返す severity `MEDIUM` をパースできず、スキャンが exit 2 で失敗していました。

Semgrep 公式イメージを `semgrep/semgrep:1.170.0` に更新し、あわせて `CRITICAL` / `HIGH` / `MEDIUM` / `LOW` を Finding スコアへマッピングできるようにしています。

| severity | 変更前スコア | 変更後スコア |
|---|---|---|
| CRITICAL | 0.0 | 0.9 |
| HIGH | 0.0 | ERROR と同じ（impact/likelihood で 0.4–0.8） |
| MEDIUM | 0.0 | 0.3（WARNING 相当） |
| LOW | 0.0 | 0.1（INFO 相当） |
| ERROR / WARNING / INFO | 従来どおり | 従来どおり |

## レビュー観点例

- [ ] Semgrep 1.46.0 から 1.170.0 へのジャンプ幅が、JSON 出力や CLI 互換の観点で許容できる点
- [ ] 新 severity のスコア対応が、既存 ERROR/WARNING/INFO のスコアを壊していない点
- [ ] CRITICAL=0.9 / HIGH≈ERROR / MEDIUM≈WARNING / LOW≈INFO の対応が、RISKEN の Finding 優先度として妥当な点
- [ ] Dockerfile のベースイメージを `returntocorp/semgrep` から `semgrep/semgrep` へ変更してもビルド・実行に問題ない点


Made with [Cursor](https://cursor.com)