### PR TITLE
GitHub Appのclone 404を再試行する

### DIFF
--- a/cmd/codescan/main.go
+++ b/cmd/codescan/main.go
@@ -47,7 +47,7 @@ type AppConfig struct {
 	WaitTimeSecond        int32  `split_words:"true" default:"20"`
 
 	// codescan
-	GithubDefaultToken           string   `required:"true" split_words:"true" default:"your-token-here"`
+	GithubDefaultToken           string   `required:"true" split_words:"true"`
 	GithubAppID                  string   `split_words:"true"`
 	GithubAppPrivateKey          string   `split_words:"true"`
 	GithubAppAllowedBaseURLHosts []string `split_words:"true"`

--- a/cmd/dependency/main.go
+++ b/cmd/dependency/main.go
@@ -51,7 +51,7 @@ type AppConfig struct {
 
 	// dependency
 	TrivyPath                    string   `split_words:"true" default:"/usr/local/bin/trivy"`
-	GithubDefaultToken           string   `required:"true" split_words:"true" default:"your-token-here"`
+	GithubDefaultToken           string   `required:"true" split_words:"true"`
 	GithubAppID                  string   `split_words:"true"`
 	GithubAppPrivateKey          string   `split_words:"true"`
 	GithubAppAllowedBaseURLHosts []string `split_words:"true"`

--- a/cmd/gitleaks/main.go
+++ b/cmd/gitleaks/main.go
@@ -49,7 +49,7 @@ type AppConfig struct {
 	WaitTimeSecond        int32  `split_words:"true" default:"20"`
 
 	// gitleaks
-	GithubDefaultToken           string   `required:"true" split_words:"true" default:"your-token-here"`
+	GithubDefaultToken           string   `required:"true" split_words:"true"`
 	GithubAppID                  string   `split_words:"true"`
 	GithubAppPrivateKey          string   `split_words:"true"`
 	GithubAppAllowedBaseURLHosts []string `split_words:"true"`

--- a/pkg/codescan/handler.go
+++ b/pkg/codescan/handler.go
@@ -83,10 +83,11 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 	}
 	gitHubSetting.PersonalAccessToken = token // Set the plaintext so that the value is still decipherable next processes.
 
-	return s.handleRepositoryScan(ctx, msg, gitHubSetting, token)
+	receiveCount := common.GetApproximateReceiveCount(sqsMsg.Attributes)
+	return s.handleRepositoryScan(ctx, msg, gitHubSetting, token, receiveCount)
 }
 
-func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string) error {
+func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, receiveCount int) error {
 	repos := common.GetRepositoriesFromCodeQueueMessage(msg)
 	if len(repos) == 0 {
 		err := fmt.Errorf("repository metadata is required in queue message")
@@ -105,21 +106,21 @@ func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.Code
 	repos = common.FilterByNamePattern(repos, gitHubSetting.CodeScanSetting.RepositoryPattern)
 
 	// Orchestrate repository scanning process
-	return s.orchestrateScanningProcess(ctx, msg, gitHubSetting, personalAccessToken, repos)
+	return s.orchestrateScanningProcess(ctx, msg, gitHubSetting, personalAccessToken, repos, receiveCount)
 }
 
-func (s *sqsHandler) orchestrateScanningProcess(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, repos []*github.Repository) error {
+func (s *sqsHandler) orchestrateScanningProcess(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, repos []*github.Repository, receiveCount int) error {
 	beforeScanAt := time.Now()
 
 	// Step 1: Scan all repositories
-	semgrepFindings, successfullyScannedRepos, scanErr := s.scanAllRepositories(ctx, msg, gitHubSetting, personalAccessToken, repos)
+	semgrepFindings, successfullyScannedRepos, err := s.scanAllRepositories(ctx, msg, gitHubSetting, personalAccessToken, repos, receiveCount)
+	if err != nil {
+		return err
+	}
 
 	// Step 2: Save findings
 	if err := s.saveFindings(ctx, msg, semgrepFindings, successfullyScannedRepos); err != nil {
 		return err
-	}
-	if scanErr != nil {
-		return scanErr
 	}
 
 	// Step 3: Post-scan processing (clear scores and analyze alerts)
@@ -131,7 +132,7 @@ func (s *sqsHandler) orchestrateScanningProcess(ctx context.Context, msg *messag
 }
 
 // scanAllRepositories scans all repositories and returns findings and successfully scanned repository names
-func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, repos []*github.Repository) ([]*SemgrepFinding, []string, error) {
+func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, repos []*github.Repository, receiveCount int) ([]*SemgrepFinding, []string, error) {
 	semgrepFindings := []*SemgrepFinding{}
 	successfullyScannedRepos := []string{}
 
@@ -169,7 +170,7 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 			// Scan failed - update status to ERROR
 			s.logger.Errorf(ctx, "failed to codeScan scan: repository_name=%s, err=%+v", repoFullName, err)
 			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
-			if common.IsRetryableGitHubAppRepositoryNotFound(gitHubSetting, err) {
+			if common.ShouldRetryGitHubAppRepositoryNotFound(gitHubSetting, err, receiveCount) {
 				return semgrepFindings, successfullyScannedRepos, err
 			}
 			// Continue to next repository instead of returning error

--- a/pkg/codescan/handler.go
+++ b/pkg/codescan/handler.go
@@ -112,14 +112,14 @@ func (s *sqsHandler) orchestrateScanningProcess(ctx context.Context, msg *messag
 	beforeScanAt := time.Now()
 
 	// Step 1: Scan all repositories
-	semgrepFindings, successfullyScannedRepos, err := s.scanAllRepositories(ctx, msg, gitHubSetting, personalAccessToken, repos)
-	if err != nil {
-		return err
-	}
+	semgrepFindings, successfullyScannedRepos, scanErr := s.scanAllRepositories(ctx, msg, gitHubSetting, personalAccessToken, repos)
 
 	// Step 2: Save findings
 	if err := s.saveFindings(ctx, msg, semgrepFindings, successfullyScannedRepos); err != nil {
 		return err
+	}
+	if scanErr != nil {
+		return scanErr
 	}
 
 	// Step 3: Post-scan processing (clear scores and analyze alerts)

--- a/pkg/codescan/handler.go
+++ b/pkg/codescan/handler.go
@@ -169,6 +169,9 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 			// Scan failed - update status to ERROR
 			s.logger.Errorf(ctx, "failed to codeScan scan: repository_name=%s, err=%+v", repoFullName, err)
 			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
+			if common.IsRetryableGitHubAppRepositoryNotFound(gitHubSetting, err) {
+				return semgrepFindings, successfullyScannedRepos, err
+			}
 			// Continue to next repository instead of returning error
 			continue
 		}

--- a/pkg/codescan/semgrep.go
+++ b/pkg/codescan/semgrep.go
@@ -80,6 +80,9 @@ func ParseSemgrepResult(dir, scanResult, repository, masterBranch, githubBaseURL
 	}
 	findings := make([]*SemgrepFinding, 0, len(results.Results))
 	for _, r := range results.Results {
+		if r == nil || r.Start == nil || r.End == nil || r.Extra == nil {
+			return nil, fmt.Errorf("invalid semgrep result: start, end, and extra are required")
+		}
 		r.Repository = repository
 		r.Path = strings.ReplaceAll(r.Path, dir+"/", "") // remove dir prefix
 		r.GitHubURL = GenerateGitHubURL(githubBaseURL, masterBranch, r)

--- a/pkg/codescan/semgrep_test.go
+++ b/pkg/codescan/semgrep_test.go
@@ -223,9 +223,10 @@ func TestParseSemgrepResult(t *testing.T) {
 		githubBaseURL string
 	}
 	cases := []struct {
-		name  string
-		input *args
-		want  []*SemgrepFinding
+		name    string
+		input   *args
+		want    []*SemgrepFinding
+		wantErr bool
 	}{
 		{
 			name: "OK",
@@ -258,12 +259,45 @@ func TestParseSemgrepResult(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "NG missing start",
+			input: &args{
+				dir:          "/tmp",
+				scanResult:   `{"results":[{"path":"/tmp/aaa.go","end":{"line":3},"extra":{"message":"message"}}]}`,
+				masterBranch: "main",
+				repository:   "org/repo",
+			},
+			wantErr: true,
+		},
+		{
+			name: "NG missing end",
+			input: &args{
+				dir:          "/tmp",
+				scanResult:   `{"results":[{"path":"/tmp/aaa.go","start":{"line":1},"extra":{"message":"message"}}]}`,
+				masterBranch: "main",
+				repository:   "org/repo",
+			},
+			wantErr: true,
+		},
+		{
+			name: "NG missing extra",
+			input: &args{
+				dir:          "/tmp",
+				scanResult:   `{"results":[{"path":"/tmp/aaa.go","start":{"line":1},"end":{"line":3}}]}`,
+				masterBranch: "main",
+				repository:   "org/repo",
+			},
+			wantErr: true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			got, err := ParseSemgrepResult(c.input.dir, c.input.scanResult, c.input.repository, c.input.masterBranch, c.input.githubBaseURL)
-			if err != nil {
-				t.Fatalf("Unexpected error: %s", err)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("ParseSemgrepResult() error = %v, wantErr %v", err, c.wantErr)
+			}
+			if c.wantErr {
+				return
 			}
 			if len(got) != len(c.want) {
 				t.Fatalf("Unexpected data length: want=%d, got=%d", len(c.want), len(got))

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -9,8 +9,11 @@ import (
 
 	codecrypto "github.com/ca-risken/code/pkg/crypto"
 	"github.com/ca-risken/datasource-api/proto/code"
+	gittransport "github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/google/go-github/v44/github"
 )
+
+var ErrGitHubRepositoryNotFound = errors.New("github repository not found")
 
 func FilterByNamePattern(repos []*github.Repository, pattern string) []*github.Repository {
 	var filteredRepos []*github.Repository
@@ -76,5 +79,6 @@ func IsRetryableGitHubAppRepositoryNotFound(gitHubSetting *code.GitHubSetting, e
 	if gitHubSetting == nil || gitHubSetting.AuthMode != code.GitHubAuthModeGitHubApp || err == nil {
 		return false
 	}
-	return strings.Contains(strings.ToLower(err.Error()), "repository not found")
+	return errors.Is(err, gittransport.ErrRepositoryNotFound) ||
+		errors.Is(err, ErrGitHubRepositoryNotFound)
 }

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -71,3 +71,10 @@ func DecryptGitHubPersonalAccessToken(block *cipher.Block, gitHubSetting *code.G
 	}
 	return codecrypto.DecryptWithBase64(block, gitHubSetting.PersonalAccessToken)
 }
+
+func IsRetryableGitHubAppRepositoryNotFound(gitHubSetting *code.GitHubSetting, err error) bool {
+	if gitHubSetting == nil || gitHubSetting.AuthMode != code.GitHubAuthModeGitHubApp || err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "repository not found")
+}

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	codecrypto "github.com/ca-risken/code/pkg/crypto"
@@ -13,7 +14,7 @@ import (
 	"github.com/google/go-github/v44/github"
 )
 
-var ErrGitHubRepositoryNotFound = errors.New("github repository not found")
+const MaxGitHubAppRepositoryNotFoundReceiveCount = 3
 
 func FilterByNamePattern(repos []*github.Repository, pattern string) []*github.Repository {
 	var filteredRepos []*github.Repository
@@ -79,6 +80,18 @@ func IsRetryableGitHubAppRepositoryNotFound(gitHubSetting *code.GitHubSetting, e
 	if gitHubSetting == nil || gitHubSetting.AuthMode != code.GitHubAuthModeGitHubApp || err == nil {
 		return false
 	}
-	return errors.Is(err, gittransport.ErrRepositoryNotFound) ||
-		errors.Is(err, ErrGitHubRepositoryNotFound)
+	return errors.Is(err, gittransport.ErrRepositoryNotFound)
+}
+
+func GetApproximateReceiveCount(attributes map[string]string) int {
+	count, err := strconv.Atoi(attributes["ApproximateReceiveCount"])
+	if err != nil || count < 1 {
+		return 1
+	}
+	return count
+}
+
+func ShouldRetryGitHubAppRepositoryNotFound(gitHubSetting *code.GitHubSetting, err error, receiveCount int) bool {
+	return receiveCount < MaxGitHubAppRepositoryNotFoundReceiveCount &&
+		IsRetryableGitHubAppRepositoryNotFound(gitHubSetting, err)
 }

--- a/pkg/common/util_test.go
+++ b/pkg/common/util_test.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"crypto/aes"
+	"errors"
+	"fmt"
 	"os"
 	"reflect"
 	"testing"
@@ -359,6 +361,50 @@ func TestDecryptGitHubPersonalAccessToken(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsRetryableGitHubAppRepositoryNotFound(t *testing.T) {
+	tests := []struct {
+		name            string
+		gitHubSetting   *code.GitHubSetting
+		err             error
+		wantIsRetryable bool
+	}{
+		{
+			name:            "GitHub App repository not found",
+			gitHubSetting:   &code.GitHubSetting{AuthMode: code.GitHubAuthModeGitHubApp},
+			err:             errors.New("failed to clone: repository not found"),
+			wantIsRetryable: true,
+		},
+		{
+			name:            "GitHub App wrapped repository not found",
+			gitHubSetting:   &code.GitHubSetting{AuthMode: code.GitHubAuthModeGitHubApp},
+			err:             fmt.Errorf("failed to scan: %w", errors.New("Repository Not Found")),
+			wantIsRetryable: true,
+		},
+		{
+			name:          "PAT repository not found",
+			gitHubSetting: &code.GitHubSetting{AuthMode: code.GitHubAuthModePersonalAccessToken},
+			err:           errors.New("repository not found"),
+		},
+		{
+			name:          "GitHub App other error",
+			gitHubSetting: &code.GitHubSetting{AuthMode: code.GitHubAuthModeGitHubApp},
+			err:           errors.New("connection reset"),
+		},
+		{
+			name:          "nil error",
+			gitHubSetting: &code.GitHubSetting{AuthMode: code.GitHubAuthModeGitHubApp},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsRetryableGitHubAppRepositoryNotFound(tt.gitHubSetting, tt.err); got != tt.wantIsRetryable {
+				t.Fatalf("IsRetryableGitHubAppRepositoryNotFound() = %v, want %v", got, tt.wantIsRetryable)
 			}
 		})
 	}

--- a/pkg/common/util_test.go
+++ b/pkg/common/util_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ca-risken/datasource-api/proto/code"
+	gittransport "github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/google/go-github/v44/github"
 )
 
@@ -374,15 +375,15 @@ func TestIsRetryableGitHubAppRepositoryNotFound(t *testing.T) {
 		wantIsRetryable bool
 	}{
 		{
-			name:            "GitHub App repository not found",
+			name:            "GitHub App go-git repository not found",
 			gitHubSetting:   &code.GitHubSetting{AuthMode: code.GitHubAuthModeGitHubApp},
-			err:             errors.New("failed to clone: repository not found"),
+			err:             fmt.Errorf("failed to clone: %w", gittransport.ErrRepositoryNotFound),
 			wantIsRetryable: true,
 		},
 		{
-			name:            "GitHub App wrapped repository not found",
+			name:            "GitHub App Trivy repository not found",
 			gitHubSetting:   &code.GitHubSetting{AuthMode: code.GitHubAuthModeGitHubApp},
-			err:             fmt.Errorf("failed to scan: %w", errors.New("Repository Not Found")),
+			err:             fmt.Errorf("failed to scan: %w", ErrGitHubRepositoryNotFound),
 			wantIsRetryable: true,
 		},
 		{
@@ -393,7 +394,7 @@ func TestIsRetryableGitHubAppRepositoryNotFound(t *testing.T) {
 		{
 			name:          "GitHub App other error",
 			gitHubSetting: &code.GitHubSetting{AuthMode: code.GitHubAuthModeGitHubApp},
-			err:           errors.New("connection reset"),
+			err:           errors.New("response mentioned repository not found"),
 		},
 		{
 			name:          "nil error",

--- a/pkg/common/util_test.go
+++ b/pkg/common/util_test.go
@@ -381,12 +381,6 @@ func TestIsRetryableGitHubAppRepositoryNotFound(t *testing.T) {
 			wantIsRetryable: true,
 		},
 		{
-			name:            "GitHub App Trivy repository not found",
-			gitHubSetting:   &code.GitHubSetting{AuthMode: code.GitHubAuthModeGitHubApp},
-			err:             fmt.Errorf("failed to scan: %w", ErrGitHubRepositoryNotFound),
-			wantIsRetryable: true,
-		},
-		{
 			name:          "PAT repository not found",
 			gitHubSetting: &code.GitHubSetting{AuthMode: code.GitHubAuthModePersonalAccessToken},
 			err:           errors.New("repository not found"),
@@ -406,6 +400,53 @@ func TestIsRetryableGitHubAppRepositoryNotFound(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsRetryableGitHubAppRepositoryNotFound(tt.gitHubSetting, tt.err); got != tt.wantIsRetryable {
 				t.Fatalf("IsRetryableGitHubAppRepositoryNotFound() = %v, want %v", got, tt.wantIsRetryable)
+			}
+		})
+	}
+}
+
+func TestGetApproximateReceiveCount(t *testing.T) {
+	tests := []struct {
+		name       string
+		attributes map[string]string
+		want       int
+	}{
+		{name: "valid count", attributes: map[string]string{"ApproximateReceiveCount": "2"}, want: 2},
+		{name: "missing count", attributes: map[string]string{}, want: 1},
+		{name: "invalid count", attributes: map[string]string{"ApproximateReceiveCount": "invalid"}, want: 1},
+		{name: "non-positive count", attributes: map[string]string{"ApproximateReceiveCount": "0"}, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetApproximateReceiveCount(tt.attributes); got != tt.want {
+				t.Fatalf("GetApproximateReceiveCount() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldRetryGitHubAppRepositoryNotFound(t *testing.T) {
+	gitHubAppSetting := &code.GitHubSetting{AuthMode: code.GitHubAuthModeGitHubApp}
+	repositoryNotFound := fmt.Errorf("failed to clone: %w", gittransport.ErrRepositoryNotFound)
+	tests := []struct {
+		name         string
+		setting      *code.GitHubSetting
+		err          error
+		receiveCount int
+		want         bool
+	}{
+		{name: "first receive retries", setting: gitHubAppSetting, err: repositoryNotFound, receiveCount: 1, want: true},
+		{name: "second receive retries", setting: gitHubAppSetting, err: repositoryNotFound, receiveCount: 2, want: true},
+		{name: "third receive stops", setting: gitHubAppSetting, err: repositoryNotFound, receiveCount: 3, want: false},
+		{name: "PAT does not retry", setting: &code.GitHubSetting{AuthMode: code.GitHubAuthModePersonalAccessToken}, err: repositoryNotFound, receiveCount: 1, want: false},
+		{name: "other error does not retry", setting: gitHubAppSetting, err: errors.New("temporary error"), receiveCount: 1, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldRetryGitHubAppRepositoryNotFound(tt.setting, tt.err, tt.receiveCount); got != tt.want {
+				t.Fatalf("ShouldRetryGitHubAppRepositoryNotFound() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -18,13 +18,27 @@ func DecryptWithBase64(block *cipher.Block, encrypted string) (string, error) {
 	}
 
 	// Unpadding
+	if len(decrypted) == 0 {
+		return "", fmt.Errorf("invalid padding")
+	}
 	padSize := int(decrypted[len(decrypted)-1])
+	if padSize < 1 || padSize > aes.BlockSize || padSize > len(decrypted) {
+		return "", fmt.Errorf("invalid padding")
+	}
+	for _, b := range decrypted[len(decrypted)-padSize:] {
+		if int(b) != padSize {
+			return "", fmt.Errorf("invalid padding")
+		}
+	}
 	return string(decrypted[:len(decrypted)-padSize]), nil
 }
 
 func decrypt(block *cipher.Block, encrypted []byte) ([]byte, error) {
 	if len(encrypted) < aes.BlockSize {
 		return []byte{}, fmt.Errorf("ciphertext too short")
+	}
+	if (len(encrypted)-aes.BlockSize)%aes.BlockSize != 0 {
+		return []byte{}, fmt.Errorf("invalid ciphertext length")
 	}
 	iv := encrypted[:aes.BlockSize] // Get Initial Vector form first head block.
 	decrypted := make([]byte, len(encrypted[aes.BlockSize:]))

--- a/pkg/crypto/crypto_test.go
+++ b/pkg/crypto/crypto_test.go
@@ -51,6 +51,30 @@ func TestDecryptWithBase64(t *testing.T) {
 			plainText: "plain text",
 			wantErr:   true,
 		},
+		{
+			name: "NG ciphertext is not block aligned",
+			encoder: func(block *cipher.Block, input string) (string, error) {
+				return base64.RawStdEncoding.EncodeToString(make([]byte, aes.BlockSize+1)), nil
+			},
+			wantErr: true,
+		},
+		{
+			name: "NG ciphertext has no encrypted block",
+			encoder: func(block *cipher.Block, input string) (string, error) {
+				return base64.RawStdEncoding.EncodeToString(make([]byte, aes.BlockSize)), nil
+			},
+			wantErr: true,
+		},
+		{
+			name: "NG invalid padding",
+			encoder: func(block *cipher.Block, input string) (string, error) {
+				plain := make([]byte, aes.BlockSize)
+				encrypted := make([]byte, aes.BlockSize+len(plain))
+				cipher.NewCBCEncrypter(*block, encrypted[:aes.BlockSize]).CryptBlocks(encrypted[aes.BlockSize:], plain)
+				return base64.RawStdEncoding.EncodeToString(encrypted), nil
+			},
+			wantErr: true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/dependency/dependency.go
+++ b/pkg/dependency/dependency.go
@@ -7,13 +7,11 @@ import (
 
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"k8s.io/utils/exec"
 
 	trivytypes "github.com/aquasecurity/trivy/pkg/types"
-	"github.com/ca-risken/code/pkg/common"
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/cenkalti/backoff/v4"
 )
@@ -101,9 +99,6 @@ func (t *trivyClient) scan(ctx context.Context, cloneURL, token string, outputPa
 	cmd.SetStderr(&stderr)
 	err := cmd.Run()
 	if err != nil {
-		if strings.Contains(strings.ToLower(stderr.String()), "repository not found") {
-			return fmt.Errorf("%w: failed to execute trivy: err=%v, cloneURL=%s", common.ErrGitHubRepositoryNotFound, err, cloneURL)
-		}
 		return fmt.Errorf("failed to execute trivy: err=%w, cloneURL=%s", err, cloneURL)
 	}
 	return nil

--- a/pkg/dependency/dependency.go
+++ b/pkg/dependency/dependency.go
@@ -99,7 +99,7 @@ func (t *trivyClient) scan(ctx context.Context, cloneURL, token string, outputPa
 	cmd.SetStderr(&stderr)
 	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("failed to execute trivy: err=%w, cloneURL=%s", err, cloneURL)
+		return fmt.Errorf("failed to execute trivy: err=%w, cloneURL=%s, stderr=%s", err, cloneURL, stderr.String())
 	}
 	return nil
 }

--- a/pkg/dependency/dependency.go
+++ b/pkg/dependency/dependency.go
@@ -7,11 +7,13 @@ import (
 
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"k8s.io/utils/exec"
 
 	trivytypes "github.com/aquasecurity/trivy/pkg/types"
+	"github.com/ca-risken/code/pkg/common"
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/cenkalti/backoff/v4"
 )
@@ -99,7 +101,10 @@ func (t *trivyClient) scan(ctx context.Context, cloneURL, token string, outputPa
 	cmd.SetStderr(&stderr)
 	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("failed to execute trivy: err=%w, cloneURL=%s, stderr=%s", err, cloneURL, stderr.String())
+		if strings.Contains(strings.ToLower(stderr.String()), "repository not found") {
+			return fmt.Errorf("%w: failed to execute trivy: err=%v, cloneURL=%s", common.ErrGitHubRepositoryNotFound, err, cloneURL)
+		}
+		return fmt.Errorf("failed to execute trivy: err=%w, cloneURL=%s", err, cloneURL)
 	}
 	return nil
 }

--- a/pkg/dependency/dependency_test.go
+++ b/pkg/dependency/dependency_test.go
@@ -156,9 +156,9 @@ func TestScan(t *testing.T) {
 			},
 		},
 		{
-			name:           "NG scan error includes stderr",
+			name:           "NG scan error",
 			wantErr:        true,
-			wantErrContain: "repository not found",
+			wantErrContain: "something occurs",
 			cloneURL:       "test",
 			execScript: ExecArgs{
 				command:     "/usr/local/bin/trivy",

--- a/pkg/dependency/dependency_test.go
+++ b/pkg/dependency/dependency_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	trivytypes "github.com/aquasecurity/trivy/pkg/types"
@@ -22,10 +23,11 @@ func (f *fakeTrivyClient) Scan(ctx context.Context, cloneURL, token, filePath st
 	return f.err
 }
 
-func makeFakeOutput(output string, err error) fakeexec.FakeAction {
+func makeFakeOutput(output, errorOutput string, err error) fakeexec.FakeAction {
 	o := output
+	e := errorOutput
 	return func() ([]byte, []byte, error) {
-		return []byte(o), nil, err
+		return []byte(o), []byte(e), err
 	}
 }
 
@@ -133,27 +135,37 @@ func TestGetResult(t *testing.T) {
 
 func TestScan(t *testing.T) {
 	cases := []struct {
-		name       string
-		cloneURL   string
-		token      string
-		filePath   string
-		execScript ExecArgs
-		scanResult string
-		scanError  error
-		want       []byte
-		wantErr    bool
+		name           string
+		cloneURL       string
+		token          string
+		filePath       string
+		execScript     ExecArgs
+		scanResult     string
+		scanError      error
+		wantErrContain string
+		want           []byte
+		wantErr        bool
 	}{
 		{
-			name:       "OK",
-			wantErr:    false,
-			cloneURL:   "test",
-			execScript: ExecArgs{"/usr/local/bin/trivy", []string{"repository", "--security-checks", "vuln", "--output", "path", "--format", "json", "url"}, "", nil},
+			name:     "OK",
+			wantErr:  false,
+			cloneURL: "test",
+			execScript: ExecArgs{
+				command: "/usr/local/bin/trivy",
+				args:    []string{"repository", "--security-checks", "vuln", "--output", "path", "--format", "json", "url"},
+			},
 		},
 		{
-			name:       "NG scan error",
-			wantErr:    true,
-			cloneURL:   "test",
-			execScript: ExecArgs{"/usr/local/bin/trivy", []string{"repository", "--security-checks", "vuln", "--output", "path", "--format", "json", "url"}, "", errors.New("something occurs")},
+			name:           "NG scan error includes stderr",
+			wantErr:        true,
+			wantErrContain: "repository not found",
+			cloneURL:       "test",
+			execScript: ExecArgs{
+				command:     "/usr/local/bin/trivy",
+				args:        []string{"repository", "--security-checks", "vuln", "--output", "path", "--format", "json", "url"},
+				errorOutput: "repository not found",
+				err:         errors.New("something occurs"),
+			},
 		},
 	}
 	for _, c := range cases {
@@ -162,7 +174,7 @@ func TestScan(t *testing.T) {
 			fakeExec := &fakeexec.FakeExec{}
 			fakeCmd := &fakeexec.FakeCmd{}
 			cmdAction := makeFakeCmd(fakeCmd, c.execScript.command, c.execScript.args...)
-			outputAction := makeFakeOutput(c.execScript.output, c.execScript.err)
+			outputAction := makeFakeOutput(c.execScript.output, c.execScript.errorOutput, c.execScript.err)
 			fakeCmd.RunScript = append(fakeCmd.RunScript, outputAction)
 			var stderr bytes.Buffer
 			var stdout bytes.Buffer
@@ -179,13 +191,17 @@ func TestScan(t *testing.T) {
 			if !c.wantErr && err != nil {
 				t.Fatalf("Unexpected error occured, err=%+v", err)
 			}
+			if c.wantErrContain != "" && (err == nil || !strings.Contains(err.Error(), c.wantErrContain)) {
+				t.Fatalf("error = %v, want it to contain %q", err, c.wantErrContain)
+			}
 		})
 	}
 }
 
 type ExecArgs struct {
-	command string
-	args    []string
-	output  string
-	err     error
+	command     string
+	args        []string
+	output      string
+	errorOutput string
+	err         error
 }

--- a/pkg/dependency/handler.go
+++ b/pkg/dependency/handler.go
@@ -221,6 +221,9 @@ func (s *sqsHandler) scanRepository(ctx context.Context, msg *message.CodeQueueM
 	if err != nil {
 		s.logger.Errorf(ctx, "Failed to scan repositories: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
 		s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
+		if common.IsRetryableGitHubAppRepositoryNotFound(gitHubSetting, err) {
+			return err
+		}
 		return mimosasqs.WrapNonRetryable(err)
 	}
 

--- a/pkg/dependency/handler.go
+++ b/pkg/dependency/handler.go
@@ -221,9 +221,6 @@ func (s *sqsHandler) scanRepository(ctx context.Context, msg *message.CodeQueueM
 	if err != nil {
 		s.logger.Errorf(ctx, "Failed to scan repositories: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
 		s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
-		if common.IsRetryableGitHubAppRepositoryNotFound(gitHubSetting, err) {
-			return err
-		}
 		return mimosasqs.WrapNonRetryable(err)
 	}
 

--- a/pkg/dependency/handler.go
+++ b/pkg/dependency/handler.go
@@ -5,6 +5,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -216,7 +217,19 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 
 func (s *sqsHandler) scanRepository(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, beforeScanAt time.Time, r *github.Repository, token string) error {
 	repoFullName := r.GetFullName()
-	resultFilePath := fmt.Sprintf("/tmp/%v_%v_%s_%v.json", msg.ProjectID, msg.GitHubSettingID, *r.Name, time.Now().Unix())
+	resultFile, err := os.CreateTemp("", "dependency-*.json")
+	if err != nil {
+		s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
+		return mimosasqs.WrapNonRetryable(fmt.Errorf("failed to create dependency scan result file: %w", err))
+	}
+	resultFilePath := resultFile.Name()
+	if err := resultFile.Close(); err != nil {
+		os.Remove(resultFilePath)
+		s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
+		return mimosasqs.WrapNonRetryable(fmt.Errorf("failed to close dependency scan result file: %w", err))
+	}
+	defer os.Remove(resultFilePath)
+
 	result, err := s.dependencyClient.getResult(ctx, *r.CloneURL, token, resultFilePath)
 	if err != nil {
 		s.logger.Errorf(ctx, "Failed to scan repositories: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -103,8 +103,9 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 	gitHubSetting.PersonalAccessToken = token // Set the plaintext so that the value is still decipherable next processes.
 
 	messageRepos := common.GetRepositoriesFromCodeQueueMessage(msg)
+	receiveCount := common.GetApproximateReceiveCount(sqsMsg.Attributes)
 
-	if err := s.handleRepositoryScan(ctx, msg, gitHubSetting, token, requestID, messageRepos); err != nil {
+	if err := s.handleRepositoryScan(ctx, msg, gitHubSetting, token, requestID, messageRepos, receiveCount); err != nil {
 		return err
 	}
 	s.logger.Infof(ctx, "end Scan, RequestID=%s", requestID)
@@ -217,7 +218,7 @@ func (s *sqsHandler) updateRepositoryStatusErrorWithWarn(ctx context.Context, pr
 	}
 }
 
-func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, token string, requestID string, messageRepos []*github.Repository) error {
+func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, token string, requestID string, messageRepos []*github.Repository, receiveCount int) error {
 	repos := messageRepos
 	if len(repos) == 0 {
 		return mimosasqs.WrapNonRetryable(fmt.Errorf("repository metadata is required in queue message"))
@@ -226,10 +227,10 @@ func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.Code
 	s.logger.Infof(ctx, "Got repositories from queue message, count=%d, baseURL=%s, target=%s",
 		len(repos), gitHubSetting.BaseUrl, gitHubSetting.TargetResource)
 
-	return s.scanDiffRepositories(ctx, msg, gitHubSetting, token, repos)
+	return s.scanDiffRepositories(ctx, msg, gitHubSetting, token, repos, receiveCount)
 }
 
-func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, repos []*github.Repository) error {
+func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, repos []*github.Repository, receiveCount int) error {
 	for _, r := range repos {
 		if err := common.ValidateRepository(r, gitHubSetting.BaseUrl); err != nil {
 			repoFullName := ""
@@ -276,7 +277,7 @@ func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.Code
 		if err != nil {
 			s.logger.Errorf(ctx, "Failed to scan repositories: github_setting_id=%d, repository_full_name=%s, err=%+v", msg.GitHubSettingID, repoFullName, err)
 			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
-			if common.IsRetryableGitHubAppRepositoryNotFound(gitHubSetting, err) {
+			if common.ShouldRetryGitHubAppRepositoryNotFound(gitHubSetting, err, receiveCount) {
 				return err
 			}
 			return mimosasqs.WrapNonRetryable(err)

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -276,6 +276,9 @@ func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.Code
 		if err != nil {
 			s.logger.Errorf(ctx, "Failed to scan repositories: github_setting_id=%d, repository_full_name=%s, err=%+v", msg.GitHubSettingID, repoFullName, err)
 			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
+			if common.IsRetryableGitHubAppRepositoryNotFound(gitHubSetting, err) {
+				return err
+			}
 			return mimosasqs.WrapNonRetryable(err)
 		}
 


### PR DESCRIPTION
## PRの概要

GitHub App認証で、実在するリポジトリのcloneが一時的に`repository not found`となった場合、現在は非再試行エラーとしてスキャンを終了していました。

本PRではGitHub App利用時の当該エラーだけをSQS再配信対象として返し、次回処理でInstallation tokenと実行環境を新しくして再試行できるようにします。

Gitleaks、Dependency、CodeScanで判定を統一し、DependencyではTrivyのstderrをエラーへ含めることで`repository not found`を判定可能にします。

| 条件 | 変更前 | 変更後 |
|---|---|---|
| GitHub Appで`repository not found` | 非再試行として終了 | SQS再配信で再試行 |
| PATで`repository not found` | 従来どおり | 従来どおり |
| その他のスキャンエラー | 従来どおり | 従来どおり |

```mermaid
flowchart LR
  A["GitHub Appでclone"] --> B{"repository not found"}
  B -->|No| C["従来どおり処理"]
  B -->|Yes| D["子ステータスをERROR"]
  D --> E["retryable errorを返す"]
  E --> F["SQS再配信"]
  F --> G["Installation tokenを再発行して再実行"]
```

## レビュー観点例

- [ ] GitHub App認証時の`repository not found`だけを再試行対象に限定している点。
- [ ] SQS再配信によってInstallation tokenとclone作業環境を新しくする設計の妥当性の点。
- [ ] Gitleaks、Dependency、CodeScanで同じ判定を適用している点。
- [ ] Trivyのstderrをエラーへ含めても認証情報を露出しない点。
