### PR TITLE
初回スキャン時の子ステータス二重更新を抑止する

### DIFF
--- a/pkg/codescan/handler.go
+++ b/pkg/codescan/handler.go
@@ -159,9 +159,11 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 			continue
 		}
 
-		// Update repository status to IN_PROGRESS
-		if err := s.updateRepositoryStatusInProgress(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName); err != nil {
-			s.logger.Warnf(ctx, "Failed to update repository status to IN_PROGRESS: repository_name=%s, err=%+v", repoFullName, err)
+		// Initial delivery was already initialized before enqueueing. Restore IN_PROGRESS only when retrying.
+		if common.ShouldUpdateRepositoryStatusInProgress(receiveCount) {
+			if err := s.updateRepositoryStatusInProgress(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName); err != nil {
+				s.logger.Warnf(ctx, "Failed to update repository status to IN_PROGRESS: repository_name=%s, err=%+v", repoFullName, err)
+			}
 		}
 
 		// Scan source code

--- a/pkg/codescan/handler.go
+++ b/pkg/codescan/handler.go
@@ -147,7 +147,8 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, r.GetFullName(), err.Error())
 			return semgrepFindings, successfullyScannedRepos, mimosasqs.WrapNonRetryable(err)
 		}
-		if s.skipScan(ctx, r, s.limitRepositorySizeKb) {
+		if skip, status, statusDetail := s.skipScan(ctx, r, s.limitRepositorySizeKb); skip {
+			s.finalizeSkippedRepositoryStatus(ctx, msg.ProjectID, msg.GitHubSettingID, r, status, statusDetail)
 			continue
 		}
 
@@ -224,10 +225,10 @@ func (s *sqsHandler) postScanProcessing(ctx context.Context, msg *message.CodeQu
 	return nil
 }
 
-func (s *sqsHandler) skipScan(ctx context.Context, repo *github.Repository, limitRepositorySize int) bool {
+func (s *sqsHandler) skipScan(ctx context.Context, repo *github.Repository, limitRepositorySize int) (bool, code.Status, string) {
 	if repo == nil {
 		s.logger.Warnf(ctx, "Skip scan repository(data not found)")
-		return true
+		return true, code.Status_ERROR, "Skipped: repository data not found"
 	}
 
 	repoName := ""
@@ -236,27 +237,27 @@ func (s *sqsHandler) skipScan(ctx context.Context, repo *github.Repository, limi
 	}
 	if repo.Archived != nil && *repo.Archived {
 		s.logger.Infof(ctx, "Skip scan for %s repository(archived)", repoName)
-		return true
+		return true, code.Status_OK, "Skipped: repository is archived"
 	}
 	if repo.Fork != nil && *repo.Fork {
 		s.logger.Infof(ctx, "Skip scan for %s repository(fork repo)", repoName)
-		return true
+		return true, code.Status_OK, "Skipped: repository is a fork"
 	}
 	if repo.Disabled != nil && *repo.Disabled {
 		s.logger.Infof(ctx, "Skip scan for %s repository(disabled)", repoName)
-		return true
+		return true, code.Status_OK, "Skipped: repository is disabled"
 	}
 	if repo.Size != nil && *repo.Size < 1 {
 		s.logger.Infof(ctx, "Skip scan for %s repository(empty)", repoName)
-		return true
+		return true, code.Status_OK, "Skipped: repository is empty"
 	}
 
 	// Hard limit size
 	if repo.Size != nil && *repo.Size > limitRepositorySize {
 		s.logger.Warnf(ctx, "Skip scan for %s repository(too big size, limit=%dkb, size(kb)=%dkb)", repoName, limitRepositorySize, *repo.Size)
-		return true
+		return true, code.Status_ERROR, fmt.Sprintf("Skipped: repository size exceeds limit (limit=%dKB, size=%dKB)", limitRepositorySize, *repo.Size)
 	}
-	return false
+	return false, code.Status_UNKNOWN, ""
 }
 
 func (s *sqsHandler) getGitHubSetting(ctx context.Context, projectID, GitHubSettingID uint32) (*code.GitHubSetting, error) {
@@ -307,6 +308,18 @@ func (s *sqsHandler) updateRepositoryStatus(ctx context.Context, projectID, gith
 func (s *sqsHandler) updateRepositoryStatusErrorWithWarn(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName, statusDetail string) {
 	if err := s.updateRepositoryStatusError(ctx, projectID, githubSettingID, repositoryFullName, statusDetail); err != nil {
 		s.logger.Warnf(ctx, "Failed to update repository status error: repository_name=%s, err=%+v", repositoryFullName, err)
+	}
+}
+
+// Repositories are initialized to IN_PROGRESS before enqueueing, so a skipped repository must be
+// finalized here. Otherwise it stays IN_PROGRESS and the parent setting never leaves IN_PROGRESS.
+func (s *sqsHandler) finalizeSkippedRepositoryStatus(ctx context.Context, projectID, githubSettingID uint32, repo *github.Repository, status code.Status, statusDetail string) {
+	repositoryFullName := repo.GetFullName()
+	if repositoryFullName == "" {
+		return
+	}
+	if err := s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, status, statusDetail); err != nil {
+		s.logger.Warnf(ctx, "Failed to finalize skipped repository status: repository_name=%s, err=%+v", repositoryFullName, err)
 	}
 }
 

--- a/pkg/codescan/handler_test.go
+++ b/pkg/codescan/handler_test.go
@@ -6,8 +6,78 @@ import (
 	"time"
 
 	"github.com/ca-risken/common/pkg/logging"
+	"github.com/ca-risken/datasource-api/proto/code"
+	"github.com/ca-risken/datasource-api/proto/code/mocks"
 	"github.com/google/go-github/v44/github"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
+
+func TestFinalizeSkippedRepositoryStatus(t *testing.T) {
+	tests := []struct {
+		name         string
+		repo         *github.Repository
+		status       code.Status
+		statusDetail string
+		prepareMock  func(*mocks.CodeServiceClient)
+	}{
+		{
+			name:         "update status to OK",
+			repo:         &github.Repository{FullName: github.String("owner/repo")},
+			status:       code.Status_OK,
+			statusDetail: "Skipped: repository is archived",
+			prepareMock: func(mockCode *mocks.CodeServiceClient) {
+				mockCode.
+					On("PutCodeScanRepository", mock.Anything, mock.MatchedBy(func(req *code.PutCodeScanRepositoryRequest) bool {
+						if req == nil || req.CodeScanRepository == nil {
+							return false
+						}
+						return req.ProjectId == 1 &&
+							req.CodeScanRepository.GithubSettingId == 2 &&
+							req.CodeScanRepository.RepositoryFullName == "owner/repo" &&
+							req.CodeScanRepository.Status == code.Status_OK &&
+							req.CodeScanRepository.StatusDetail == "Skipped: repository is archived"
+					})).
+					Return(&emptypb.Empty{}, nil).
+					Once()
+			},
+		},
+		{
+			name:   "no update for repository without full name",
+			repo:   nil,
+			status: code.Status_OK,
+		},
+		{
+			name:         "update size limit skip to ERROR",
+			repo:         &github.Repository{FullName: github.String("owner/repo")},
+			status:       code.Status_ERROR,
+			statusDetail: "Skipped: repository size exceeds limit",
+			prepareMock: func(mockCode *mocks.CodeServiceClient) {
+				mockCode.
+					On("PutCodeScanRepository", mock.Anything, mock.MatchedBy(func(req *code.PutCodeScanRepositoryRequest) bool {
+						return req.CodeScanRepository.Status == code.Status_ERROR &&
+							req.CodeScanRepository.StatusDetail == "Skipped: repository size exceeds limit"
+					})).
+					Return(&emptypb.Empty{}, nil).
+					Once()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCode := mocks.CodeServiceClient{}
+			if tt.prepareMock != nil {
+				tt.prepareMock(&mockCode)
+			}
+			s := sqsHandler{codeClient: &mockCode, logger: logging.NewLogger()}
+
+			s.finalizeSkippedRepositoryStatus(context.Background(), 1, 2, tt.repo, tt.status, tt.statusDetail)
+
+			mockCode.AssertExpectations(t)
+		})
+	}
+}
 
 func TestSkipScan(t *testing.T) {
 	now := time.Now()
@@ -125,7 +195,7 @@ func TestSkipScan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := sqsHandler{logger: logging.NewLogger()}
-			if got := s.skipScan(tt.args.ctx, tt.args.repo, tt.args.limitRepositorySize); got != tt.want {
+			if got, _, _ := s.skipScan(tt.args.ctx, tt.args.repo, tt.args.limitRepositorySize); got != tt.want {
 				t.Errorf("skipScan() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -91,6 +91,10 @@ func GetApproximateReceiveCount(attributes map[string]string) int {
 	return count
 }
 
+func ShouldUpdateRepositoryStatusInProgress(receiveCount int) bool {
+	return receiveCount > 1
+}
+
 func ShouldRetryGitHubAppRepositoryNotFound(gitHubSetting *code.GitHubSetting, err error, receiveCount int) bool {
 	return receiveCount < MaxGitHubAppRepositoryNotFoundReceiveCount &&
 		IsRetryableGitHubAppRepositoryNotFound(gitHubSetting, err)

--- a/pkg/common/util_test.go
+++ b/pkg/common/util_test.go
@@ -426,6 +426,26 @@ func TestGetApproximateReceiveCount(t *testing.T) {
 	}
 }
 
+func TestShouldUpdateRepositoryStatusInProgress(t *testing.T) {
+	tests := []struct {
+		name         string
+		receiveCount int
+		want         bool
+	}{
+		{name: "initial delivery is already initialized", receiveCount: 1, want: false},
+		{name: "second delivery restores in progress", receiveCount: 2, want: true},
+		{name: "third delivery restores in progress", receiveCount: 3, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldUpdateRepositoryStatusInProgress(tt.receiveCount); got != tt.want {
+				t.Fatalf("ShouldUpdateRepositoryStatusInProgress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestShouldRetryGitHubAppRepositoryNotFound(t *testing.T) {
 	gitHubAppSetting := &code.GitHubSetting{AuthMode: code.GitHubAuthModeGitHubApp}
 	repositoryNotFound := fmt.Errorf("failed to clone: %w", gittransport.ErrRepositoryNotFound)

--- a/pkg/dependency/handler.go
+++ b/pkg/dependency/handler.go
@@ -103,26 +103,26 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 	return s.handleRepositoryScan(ctx, msg, gitHubSetting, token, requestID)
 }
 
-func (s *sqsHandler) skipScan(ctx context.Context, repo *github.Repository, limitRepositorySize int) bool {
+func (s *sqsHandler) skipScan(ctx context.Context, repo *github.Repository, limitRepositorySize int) (bool, code.Status, string) {
 	repoName := repo.GetFullName()
 
 	if repo.GetFork() {
 		s.logger.Infof(ctx, "Skip scan for %s repository(fork repo)", repoName)
-		return true
+		return true, code.Status_OK, "Skipped: repository is a fork"
 	}
 	// repositoryがemptyの場合にスキャンに失敗するためスキップする
 	repoSize := repo.GetSize()
 	if repoSize == 0 {
 		s.logger.Infof(ctx, "Skip scan for %s repository(empty)", repoName)
-		return true
+		return true, code.Status_OK, "Skipped: repository is empty"
 	}
 	// Hard limit size
 	if repoSize > limitRepositorySize {
 		s.logger.Warnf(ctx, "Skip scan for %s repository(too big size, limit=%dkb, size(kb)=%dkb)", repoName, limitRepositorySize, *repo.Size)
-		return true
+		return true, code.Status_ERROR, fmt.Sprintf("Skipped: repository size exceeds limit (limit=%dKB, size=%dKB)", limitRepositorySize, repoSize)
 	}
 
-	return false
+	return false, code.Status_UNKNOWN, ""
 }
 
 func (s *sqsHandler) getGitHubSetting(ctx context.Context, projectID, GitHubSettingID uint32) (*code.GitHubSetting, error) {
@@ -191,7 +191,8 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, r.GetFullName(), err.Error())
 			return successfullyScannedRepos, mimosasqs.WrapNonRetryable(err)
 		}
-		if s.skipScan(ctx, r, s.limitRepositorySizeKb) {
+		if skip, status, statusDetail := s.skipScan(ctx, r, s.limitRepositorySizeKb); skip {
+			s.finalizeSkippedRepositoryStatus(ctx, msg.ProjectID, msg.GitHubSettingID, r, status, statusDetail)
 			continue
 		}
 		repoFullName := r.GetFullName()
@@ -327,6 +328,18 @@ func (s *sqsHandler) updateRepositoryStatus(ctx context.Context, projectID, gith
 func (s *sqsHandler) updateRepositoryStatusErrorWithWarn(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName, statusDetail string) {
 	if err := s.updateRepositoryStatusError(ctx, projectID, githubSettingID, repositoryFullName, statusDetail); err != nil {
 		s.logger.Warnf(ctx, "Failed to update repository status error: repository_name=%s, err=%+v", repositoryFullName, err)
+	}
+}
+
+// Repositories are initialized to IN_PROGRESS before enqueueing, so a skipped repository must be
+// finalized here. Otherwise it stays IN_PROGRESS and the parent setting never leaves IN_PROGRESS.
+func (s *sqsHandler) finalizeSkippedRepositoryStatus(ctx context.Context, projectID, githubSettingID uint32, repo *github.Repository, status code.Status, statusDetail string) {
+	repositoryFullName := repo.GetFullName()
+	if repositoryFullName == "" {
+		return
+	}
+	if err := s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, status, statusDetail); err != nil {
+		s.logger.Warnf(ctx, "Failed to finalize skipped repository status: repository_name=%s, err=%+v", repositoryFullName, err)
 	}
 }
 

--- a/pkg/dependency/handler.go
+++ b/pkg/dependency/handler.go
@@ -203,10 +203,6 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 			continue
 		}
 
-		if err := s.updateRepositoryStatusInProgress(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName); err != nil {
-			s.logger.Warnf(ctx, "Failed to update repository status to IN_PROGRESS: repository_name=%s, err=%+v", repoFullName, err)
-		}
-
 		if err := s.scanRepository(ctx, msg, gitHubSetting, beforeScanAt, r, token); err != nil {
 			return successfullyScannedRepos, err
 		}
@@ -299,10 +295,6 @@ func sanitizeStatusDetail(status code.Status, statusDetail string) string {
 	statusDetail = common.CutString(statusDetail, 200)
 	// Re-sanitize after CutString to prevent invalid UTF-8 from byte-level truncation
 	return strings.ToValidUTF8(statusDetail, "")
-}
-
-func (s *sqsHandler) updateRepositoryStatusInProgress(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName string) error {
-	return s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_IN_PROGRESS, "")
 }
 
 func (s *sqsHandler) updateRepositoryStatusError(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName, statusDetail string) error {

--- a/pkg/dependency/handler.go
+++ b/pkg/dependency/handler.go
@@ -100,7 +100,8 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 	}
 	gitHubSetting.PersonalAccessToken = token // Set the plaintext so that the value is still decipherable next processes.
 
-	return s.handleRepositoryScan(ctx, msg, gitHubSetting, token, requestID)
+	receiveCount := common.GetApproximateReceiveCount(sqsMsg.Attributes)
+	return s.handleRepositoryScan(ctx, msg, gitHubSetting, token, requestID, receiveCount)
 }
 
 func (s *sqsHandler) skipScan(ctx context.Context, repo *github.Repository, limitRepositorySize int) (bool, code.Status, string) {
@@ -146,7 +147,7 @@ func (s *sqsHandler) analyzeAlert(ctx context.Context, projectID uint32) error {
 	return err
 }
 
-func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, requestID string) error {
+func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, requestID string, receiveCount int) error {
 	repos := common.GetRepositoriesFromCodeQueueMessage(msg)
 	if len(repos) == 0 {
 		err := fmt.Errorf("repository metadata is required in queue message")
@@ -161,14 +162,14 @@ func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.Code
 		requestID, len(repos), gitHubSetting.BaseUrl, gitHubSetting.TargetResource)
 	repos = common.FilterByNamePattern(repos, gitHubSetting.DependencySetting.RepositoryPattern)
 
-	return s.orchestrateScanningProcess(ctx, msg, gitHubSetting, personalAccessToken, repos, requestID)
+	return s.orchestrateScanningProcess(ctx, msg, gitHubSetting, personalAccessToken, repos, requestID, receiveCount)
 }
 
-func (s *sqsHandler) orchestrateScanningProcess(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, repos []*github.Repository, requestID string) error {
+func (s *sqsHandler) orchestrateScanningProcess(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, repos []*github.Repository, requestID string, receiveCount int) error {
 	beforeScanAt := time.Now()
 
 	// Step 1: Scan repositories (includes per-repo find/put/clear)
-	successfullyScannedRepos, err := s.scanAllRepositories(ctx, msg, gitHubSetting, personalAccessToken, beforeScanAt, repos)
+	successfullyScannedRepos, err := s.scanAllRepositories(ctx, msg, gitHubSetting, personalAccessToken, beforeScanAt, repos, receiveCount)
 	if err != nil {
 		return err
 	}
@@ -178,7 +179,7 @@ func (s *sqsHandler) orchestrateScanningProcess(ctx context.Context, msg *messag
 }
 
 // scanAllRepositories scans all repositories and returns successfully scanned repository names
-func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, beforeScanAt time.Time, repos []*github.Repository) ([]string, error) {
+func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, personalAccessToken string, beforeScanAt time.Time, repos []*github.Repository, receiveCount int) ([]string, error) {
 	successfullyScannedRepos := []string{}
 	for _, r := range repos {
 		if err := common.ValidateRepository(r, gitHubSetting.BaseUrl); err != nil {
@@ -196,6 +197,13 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 			continue
 		}
 		repoFullName := r.GetFullName()
+
+		// Initial delivery was already initialized before enqueueing. Restore IN_PROGRESS only when retrying.
+		if common.ShouldUpdateRepositoryStatusInProgress(receiveCount) {
+			if err := s.updateRepositoryStatusInProgress(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName); err != nil {
+				s.logger.Warnf(ctx, "Failed to update repository status to IN_PROGRESS: repository_name=%s, err=%+v", repoFullName, err)
+			}
+		}
 
 		token, err := s.githubClient.ResolveAccessToken(ctx, gitHubSetting, repoFullName, personalAccessToken)
 		if err != nil {
@@ -300,6 +308,10 @@ func sanitizeStatusDetail(status code.Status, statusDetail string) string {
 
 func (s *sqsHandler) updateRepositoryStatusError(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName, statusDetail string) error {
 	return s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_ERROR, statusDetail)
+}
+
+func (s *sqsHandler) updateRepositoryStatusInProgress(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName string) error {
+	return s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_IN_PROGRESS, "")
 }
 
 func (s *sqsHandler) updateRepositoryStatusSuccess(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName string) error {

--- a/pkg/dependency/handler_test.go
+++ b/pkg/dependency/handler_test.go
@@ -11,7 +11,74 @@ import (
 	"github.com/ca-risken/datasource-api/proto/code/mocks"
 	"github.com/google/go-github/v44/github"
 	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
+
+func TestFinalizeSkippedRepositoryStatus(t *testing.T) {
+	tests := []struct {
+		name         string
+		repo         *github.Repository
+		status       code.Status
+		statusDetail string
+		prepareMock  func(*mocks.CodeServiceClient)
+	}{
+		{
+			name:         "update status to OK",
+			repo:         &github.Repository{FullName: github.String("owner/repo")},
+			status:       code.Status_OK,
+			statusDetail: "Skipped: repository is a fork",
+			prepareMock: func(mockCode *mocks.CodeServiceClient) {
+				mockCode.
+					On("PutDependencyRepository", mock.Anything, mock.MatchedBy(func(req *code.PutDependencyRepositoryRequest) bool {
+						if req == nil || req.DependencyRepository == nil {
+							return false
+						}
+						return req.ProjectId == 1 &&
+							req.DependencyRepository.GithubSettingId == 2 &&
+							req.DependencyRepository.RepositoryFullName == "owner/repo" &&
+							req.DependencyRepository.Status == code.Status_OK &&
+							req.DependencyRepository.StatusDetail == "Skipped: repository is a fork"
+					})).
+					Return(&emptypb.Empty{}, nil).
+					Once()
+			},
+		},
+		{
+			name:   "no update for repository without full name",
+			repo:   nil,
+			status: code.Status_OK,
+		},
+		{
+			name:         "update size limit skip to ERROR",
+			repo:         &github.Repository{FullName: github.String("owner/repo")},
+			status:       code.Status_ERROR,
+			statusDetail: "Skipped: repository size exceeds limit",
+			prepareMock: func(mockCode *mocks.CodeServiceClient) {
+				mockCode.
+					On("PutDependencyRepository", mock.Anything, mock.MatchedBy(func(req *code.PutDependencyRepositoryRequest) bool {
+						return req.DependencyRepository.Status == code.Status_ERROR &&
+							req.DependencyRepository.StatusDetail == "Skipped: repository size exceeds limit"
+					})).
+					Return(&emptypb.Empty{}, nil).
+					Once()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCode := mocks.CodeServiceClient{}
+			if tt.prepareMock != nil {
+				tt.prepareMock(&mockCode)
+			}
+			s := sqsHandler{codeClient: &mockCode, logger: logging.NewLogger()}
+
+			s.finalizeSkippedRepositoryStatus(context.Background(), 1, 2, tt.repo, tt.status, tt.statusDetail)
+
+			mockCode.AssertExpectations(t)
+		})
+	}
+}
 
 func TestUpdateDependencySettingStatusError(t *testing.T) {
 	tests := []struct {

--- a/pkg/dependency/handler_test.go
+++ b/pkg/dependency/handler_test.go
@@ -80,6 +80,45 @@ func TestFinalizeSkippedRepositoryStatus(t *testing.T) {
 	}
 }
 
+func TestUpdateRepositoryStatusInProgress(t *testing.T) {
+	tests := []struct {
+		name        string
+		prepareMock func(*mocks.CodeServiceClient)
+		wantErr     bool
+	}{
+		{
+			name: "update to IN_PROGRESS",
+			prepareMock: func(mockCode *mocks.CodeServiceClient) {
+				mockCode.
+					On("PutDependencyRepository", mock.Anything, mock.MatchedBy(func(req *code.PutDependencyRepositoryRequest) bool {
+						return req.ProjectId == 1 &&
+							req.DependencyRepository.GithubSettingId == 2 &&
+							req.DependencyRepository.RepositoryFullName == "owner/repo" &&
+							req.DependencyRepository.Status == code.Status_IN_PROGRESS &&
+							req.DependencyRepository.StatusDetail == ""
+					})).
+					Return(&emptypb.Empty{}, nil).
+					Once()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCode := mocks.CodeServiceClient{}
+			tt.prepareMock(&mockCode)
+			s := sqsHandler{codeClient: &mockCode, logger: logging.NewLogger()}
+
+			err := s.updateRepositoryStatusInProgress(context.Background(), 1, 2, "owner/repo")
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("updateRepositoryStatusInProgress() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			mockCode.AssertExpectations(t)
+		})
+	}
+}
+
 func TestUpdateDependencySettingStatusError(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -203,6 +242,7 @@ func TestHandleRepositoryScan(t *testing.T) {
 				}},
 				"",
 				"req-1",
+				1,
 			)
 			if tt.wantErr {
 				if err == nil {
@@ -283,7 +323,7 @@ func TestScanAllRepositories(t *testing.T) {
 				},
 			}
 
-			_, err := s.scanAllRepositories(ctx, msg, setting, "", time.Now(), tt.repos)
+			_, err := s.scanAllRepositories(ctx, msg, setting, "", time.Now(), tt.repos, 1)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -288,7 +288,7 @@ func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.Code
 		}
 
 		// Scan per repository
-		results, err := s.scanRepository(ctx, r, token, lastScannedAt, msg)
+		results, scanAt, err := s.scanRepository(ctx, r, token, lastScannedAt, msg)
 		if err != nil {
 			s.logger.Errorf(ctx, "Failed to scan repositories: github_setting_id=%d, repository_full_name=%s, err=%+v", msg.GitHubSettingID, repoFullName, err)
 			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
@@ -305,6 +305,10 @@ func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.Code
 				s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
 				return mimosasqs.WrapNonRetryable(err)
 			}
+			if err := s.updateGitleaksCache(ctx, msg, r, scanAt); err != nil {
+				s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
+				return mimosasqs.WrapNonRetryable(err)
+			}
 			if err := s.updateRepositoryStatusSuccess(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName); err != nil {
 				s.logger.Warnf(ctx, "Failed to update repository status success: repository_full_name=%s, err=%+v", repoFullName, err)
 			}
@@ -318,6 +322,11 @@ func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.Code
 			return mimosasqs.WrapNonRetryable(err)
 		}
 
+		if err := s.updateGitleaksCache(ctx, msg, r, scanAt); err != nil {
+			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
+			return mimosasqs.WrapNonRetryable(err)
+		}
+
 		// Update repository status to OK
 		if err := s.updateRepositoryStatusSuccess(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName); err != nil {
 			s.logger.Warnf(ctx, "Failed to update repository status success: repository_full_name=%s, err=%+v", repoFullName, err)
@@ -326,18 +335,18 @@ func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.Code
 	return nil
 }
 
-func (s *sqsHandler) scanRepository(ctx context.Context, r *github.Repository, token string, lastScannedAt *time.Time, msg *message.CodeQueueMessage) ([]report.Finding, error) {
+func (s *sqsHandler) scanRepository(ctx context.Context, r *github.Repository, token string, lastScannedAt *time.Time, msg *message.CodeQueueMessage) ([]report.Finding, time.Time, error) {
 	// Clone repository
 	dir, err := common.CreateCloneDir(*r.Name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create directory to clone %s: %w", *r.FullName, err)
+		return nil, time.Time{}, fmt.Errorf("failed to create directory to clone %s: %w", *r.FullName, err)
 	}
 	defer os.RemoveAll(dir)
 
 	cloneDate := time.Now()
 	err = s.githubClient.Clone(ctx, token, *r.CloneURL, dir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to clone %s: %w", *r.FullName, err)
+		return nil, time.Time{}, fmt.Errorf("failed to clone %s: %w", *r.FullName, err)
 	}
 
 	// Scan repository
@@ -348,21 +357,25 @@ func (s *sqsHandler) scanRepository(ctx context.Context, r *github.Repository, t
 	duration := getScanDuration(from, r.PushedAt.Time)
 	results, err := s.gitleaksClient.scan(ctx, dir, duration)
 	if err != nil {
-		return nil, fmt.Errorf("failed to scan %s: %w", *r.FullName, err)
+		return nil, time.Time{}, fmt.Errorf("failed to scan %s: %w", *r.FullName, err)
 	}
+	return results, cloneDate, nil
+}
 
-	// Caching scanned time
+// Cache the scan only after its resources or findings have been stored successfully.
+// Otherwise a failed registration would be skipped as already scanned on the next run.
+func (s *sqsHandler) updateGitleaksCache(ctx context.Context, msg *message.CodeQueueMessage, r *github.Repository, scanAt time.Time) error {
 	if _, err := s.codeClient.PutGitleaksCache(ctx, &code.PutGitleaksCacheRequest{
 		ProjectId: msg.ProjectID,
 		GitleaksCache: &code.GitleaksCacheForUpsert{
 			GithubSettingId:    msg.GitHubSettingID,
 			RepositoryFullName: *r.FullName,
-			ScanAt:             cloneDate.Unix(),
+			ScanAt:             scanAt.Unix(),
 		},
 	}); err != nil {
-		return nil, fmt.Errorf("failed to cache time %s: %w", *r.FullName, err)
+		return fmt.Errorf("failed to cache time %s: %w", *r.FullName, err)
 	}
-	return results, nil
+	return nil
 }
 
 func (s *sqsHandler) putResource(ctx context.Context, projectID uint32, resourceName string) error {

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -267,9 +267,11 @@ func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.Code
 			continue
 		}
 
-		// Update repository status to IN_PROGRESS
-		if err := s.updateRepositoryStatusInProgress(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName); err != nil {
-			s.logger.Warnf(ctx, "Failed to update repository status to IN_PROGRESS: repository_full_name=%s, err=%+v", repoFullName, err)
+		// Initial delivery was already initialized before enqueueing. Restore IN_PROGRESS only when retrying.
+		if common.ShouldUpdateRepositoryStatusInProgress(receiveCount) {
+			if err := s.updateRepositoryStatusInProgress(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName); err != nil {
+				s.logger.Warnf(ctx, "Failed to update repository status to IN_PROGRESS: repository_full_name=%s, err=%+v", repoFullName, err)
+			}
 		}
 
 		// Scan per repository

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -119,10 +119,10 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 	return nil
 }
 
-func (s *sqsHandler) skipScan(ctx context.Context, repo *github.Repository, lastScannedAt *time.Time, limitRepositorySize int) bool {
+func (s *sqsHandler) skipScan(ctx context.Context, repo *github.Repository, lastScannedAt *time.Time, limitRepositorySize int) (bool, code.Status, string) {
 	if repo == nil {
 		s.logger.Warnf(ctx, "Skip scan repository(data not found)")
-		return true
+		return true, code.Status_ERROR, "Skipped: repository data not found"
 	}
 
 	repoName := ""
@@ -131,34 +131,34 @@ func (s *sqsHandler) skipScan(ctx context.Context, repo *github.Repository, last
 	}
 	if repo.Archived != nil && *repo.Archived {
 		s.logger.Infof(ctx, "Skip scan for %s repository(archived)", repoName)
-		return true
+		return true, code.Status_OK, "Skipped: repository is archived"
 	}
 	if repo.Fork != nil && *repo.Fork {
 		s.logger.Infof(ctx, "Skip scan for %s repository(fork repo)", repoName)
-		return true
+		return true, code.Status_OK, "Skipped: repository is a fork"
 	}
 	if repo.Disabled != nil && *repo.Disabled {
 		s.logger.Infof(ctx, "Skip scan for %s repository(disabled)", repoName)
-		return true
+		return true, code.Status_OK, "Skipped: repository is disabled"
 	}
 	if repo.Size != nil && *repo.Size < 1 {
 		s.logger.Infof(ctx, "Skip scan for %s repository(empty)", repoName)
-		return true
+		return true, code.Status_OK, "Skipped: repository is empty"
 	}
 
 	// Hard limit size
 	if repo.Size != nil && *repo.Size > limitRepositorySize {
 		s.logger.Warnf(ctx, "Skip scan for %s repository(too big size, limit=%dkb, size(kb)=%dkb)", repoName, limitRepositorySize, *repo.Size)
-		return true
+		return true, code.Status_ERROR, fmt.Sprintf("Skipped: repository size exceeds limit (limit=%dKB, size=%dKB)", limitRepositorySize, *repo.Size)
 	}
 
 	// Check comparing pushedAt and lastScannedAt
 	if repo.PushedAt != nil && lastScannedAt != nil && repo.PushedAt.Unix() <= lastScannedAt.Unix() {
 		s.logger.Infof(ctx, "Skip scan for %s repository(already scanned)", repoName)
-		return true
+		return true, code.Status_OK, "Skipped: repository was already scanned"
 	}
 
-	return false
+	return false, code.Status_UNKNOWN, ""
 }
 
 func (s *sqsHandler) getGitHubSetting(ctx context.Context, projectID, GitHubSettingID uint32) (*code.GitHubSetting, error) {
@@ -220,12 +220,12 @@ func (s *sqsHandler) updateRepositoryStatusErrorWithWarn(ctx context.Context, pr
 
 // Repositories are initialized to IN_PROGRESS before enqueueing, so a skipped repository must be
 // finalized here. Otherwise it stays IN_PROGRESS and the parent setting never leaves IN_PROGRESS.
-func (s *sqsHandler) finalizeSkippedRepositoryStatus(ctx context.Context, projectID, githubSettingID uint32, repo *github.Repository) {
+func (s *sqsHandler) finalizeSkippedRepositoryStatus(ctx context.Context, projectID, githubSettingID uint32, repo *github.Repository, status code.Status, statusDetail string) {
 	repositoryFullName := repo.GetFullName()
 	if repositoryFullName == "" {
 		return
 	}
-	if err := s.updateRepositoryStatusSuccess(ctx, projectID, githubSettingID, repositoryFullName); err != nil {
+	if err := s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, status, statusDetail); err != nil {
 		s.logger.Warnf(ctx, "Failed to finalize skipped repository status: repository_full_name=%s, err=%+v", repositoryFullName, err)
 	}
 }
@@ -267,8 +267,8 @@ func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.Code
 			}
 		}
 
-		if s.skipScan(ctx, r, lastScannedAt, s.limitRepositorySizeKb) {
-			s.finalizeSkippedRepositoryStatus(ctx, msg.ProjectID, msg.GitHubSettingID, r)
+		if skip, status, statusDetail := s.skipScan(ctx, r, lastScannedAt, s.limitRepositorySizeKb); skip {
+			s.finalizeSkippedRepositoryStatus(ctx, msg.ProjectID, msg.GitHubSettingID, r, status, statusDetail)
 			continue
 		}
 

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -218,6 +218,18 @@ func (s *sqsHandler) updateRepositoryStatusErrorWithWarn(ctx context.Context, pr
 	}
 }
 
+// Repositories are initialized to IN_PROGRESS before enqueueing, so a skipped repository must be
+// finalized here. Otherwise it stays IN_PROGRESS and the parent setting never leaves IN_PROGRESS.
+func (s *sqsHandler) finalizeSkippedRepositoryStatus(ctx context.Context, projectID, githubSettingID uint32, repo *github.Repository) {
+	repositoryFullName := repo.GetFullName()
+	if repositoryFullName == "" {
+		return
+	}
+	if err := s.updateRepositoryStatusSuccess(ctx, projectID, githubSettingID, repositoryFullName); err != nil {
+		s.logger.Warnf(ctx, "Failed to finalize skipped repository status: repository_full_name=%s, err=%+v", repositoryFullName, err)
+	}
+}
+
 func (s *sqsHandler) handleRepositoryScan(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, token string, requestID string, messageRepos []*github.Repository, receiveCount int) error {
 	repos := messageRepos
 	if len(repos) == 0 {
@@ -256,6 +268,7 @@ func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.Code
 		}
 
 		if s.skipScan(ctx, r, lastScannedAt, s.limitRepositorySizeKb) {
+			s.finalizeSkippedRepositoryStatus(ctx, msg.ProjectID, msg.GitHubSettingID, r)
 			continue
 		}
 

--- a/pkg/gitleaks/handler_test.go
+++ b/pkg/gitleaks/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ca-risken/datasource-api/proto/code/mocks"
 	"github.com/google/go-github/v44/github"
 	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 func TestGetRepositoriesFromCodeQueueMessage(t *testing.T) {
@@ -425,6 +426,61 @@ func TestSkipScan(t *testing.T) {
 			if got := s.skipScan(tt.args.ctx, tt.args.repo, tt.args.lastScannedAt, tt.args.limitRepositorySize); got != tt.want {
 				t.Errorf("skipScan() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestFinalizeSkippedRepositoryStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		repo        *github.Repository
+		prepareMock func(*mocks.CodeServiceClient)
+	}{
+		{
+			name: "update status to OK",
+			repo: &github.Repository{FullName: github.String("owner/repo")},
+			prepareMock: func(mockCode *mocks.CodeServiceClient) {
+				mockCode.
+					On("PutGitleaksRepository", mock.Anything, mock.MatchedBy(func(req *code.PutGitleaksRepositoryRequest) bool {
+						if req == nil || req.GitleaksRepository == nil {
+							return false
+						}
+						return req.ProjectId == 1 &&
+							req.GitleaksRepository.GithubSettingId == 2 &&
+							req.GitleaksRepository.RepositoryFullName == "owner/repo" &&
+							req.GitleaksRepository.Status == code.Status_OK
+					})).
+					Return(&emptypb.Empty{}, nil).
+					Once()
+			},
+		},
+		{
+			name: "no update for repository without full name",
+			repo: nil,
+		},
+		{
+			name: "API error is only logged",
+			repo: &github.Repository{FullName: github.String("owner/repo")},
+			prepareMock: func(mockCode *mocks.CodeServiceClient) {
+				mockCode.
+					On("PutGitleaksRepository", mock.Anything, mock.Anything).
+					Return(nil, errors.New("something error")).
+					Once()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCode := mocks.CodeServiceClient{}
+			if tt.prepareMock != nil {
+				tt.prepareMock(&mockCode)
+			}
+			s := sqsHandler{codeClient: &mockCode, logger: logging.NewLogger()}
+
+			s.finalizeSkippedRepositoryStatus(context.Background(), 1, 2, tt.repo)
+
+			mockCode.AssertExpectations(t)
 		})
 	}
 }

--- a/pkg/gitleaks/handler_test.go
+++ b/pkg/gitleaks/handler_test.go
@@ -423,7 +423,7 @@ func TestSkipScan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := sqsHandler{logger: logging.NewLogger()}
-			if got := s.skipScan(tt.args.ctx, tt.args.repo, tt.args.lastScannedAt, tt.args.limitRepositorySize); got != tt.want {
+			if got, _, _ := s.skipScan(tt.args.ctx, tt.args.repo, tt.args.lastScannedAt, tt.args.limitRepositorySize); got != tt.want {
 				t.Errorf("skipScan() = %v, want %v", got, tt.want)
 			}
 		})
@@ -432,13 +432,17 @@ func TestSkipScan(t *testing.T) {
 
 func TestFinalizeSkippedRepositoryStatus(t *testing.T) {
 	tests := []struct {
-		name        string
-		repo        *github.Repository
-		prepareMock func(*mocks.CodeServiceClient)
+		name         string
+		repo         *github.Repository
+		status       code.Status
+		statusDetail string
+		prepareMock  func(*mocks.CodeServiceClient)
 	}{
 		{
-			name: "update status to OK",
-			repo: &github.Repository{FullName: github.String("owner/repo")},
+			name:         "update status to OK",
+			repo:         &github.Repository{FullName: github.String("owner/repo")},
+			status:       code.Status_OK,
+			statusDetail: "Skipped: repository was already scanned",
 			prepareMock: func(mockCode *mocks.CodeServiceClient) {
 				mockCode.
 					On("PutGitleaksRepository", mock.Anything, mock.MatchedBy(func(req *code.PutGitleaksRepositoryRequest) bool {
@@ -448,15 +452,32 @@ func TestFinalizeSkippedRepositoryStatus(t *testing.T) {
 						return req.ProjectId == 1 &&
 							req.GitleaksRepository.GithubSettingId == 2 &&
 							req.GitleaksRepository.RepositoryFullName == "owner/repo" &&
-							req.GitleaksRepository.Status == code.Status_OK
+							req.GitleaksRepository.Status == code.Status_OK &&
+							req.GitleaksRepository.StatusDetail == "Skipped: repository was already scanned"
 					})).
 					Return(&emptypb.Empty{}, nil).
 					Once()
 			},
 		},
 		{
-			name: "no update for repository without full name",
-			repo: nil,
+			name:   "no update for repository without full name",
+			repo:   nil,
+			status: code.Status_OK,
+		},
+		{
+			name:         "update size limit skip to ERROR",
+			repo:         &github.Repository{FullName: github.String("owner/repo")},
+			status:       code.Status_ERROR,
+			statusDetail: "Skipped: repository size exceeds limit",
+			prepareMock: func(mockCode *mocks.CodeServiceClient) {
+				mockCode.
+					On("PutGitleaksRepository", mock.Anything, mock.MatchedBy(func(req *code.PutGitleaksRepositoryRequest) bool {
+						return req.GitleaksRepository.Status == code.Status_ERROR &&
+							req.GitleaksRepository.StatusDetail == "Skipped: repository size exceeds limit"
+					})).
+					Return(&emptypb.Empty{}, nil).
+					Once()
+			},
 		},
 		{
 			name: "API error is only logged",
@@ -478,7 +499,7 @@ func TestFinalizeSkippedRepositoryStatus(t *testing.T) {
 			}
 			s := sqsHandler{codeClient: &mockCode, logger: logging.NewLogger()}
 
-			s.finalizeSkippedRepositoryStatus(context.Background(), 1, 2, tt.repo)
+			s.finalizeSkippedRepositoryStatus(context.Background(), 1, 2, tt.repo, tt.status, tt.statusDetail)
 
 			mockCode.AssertExpectations(t)
 		})

--- a/pkg/gitleaks/handler_test.go
+++ b/pkg/gitleaks/handler_test.go
@@ -506,6 +506,60 @@ func TestFinalizeSkippedRepositoryStatus(t *testing.T) {
 	}
 }
 
+func TestUpdateGitleaksCache(t *testing.T) {
+	scanAt := time.Unix(1710000000, 0)
+	tests := []struct {
+		name        string
+		prepareMock func(*mocks.CodeServiceClient)
+		wantErr     bool
+	}{
+		{
+			name: "cache successful scan time",
+			prepareMock: func(mockCode *mocks.CodeServiceClient) {
+				mockCode.
+					On("PutGitleaksCache", mock.Anything, mock.MatchedBy(func(req *code.PutGitleaksCacheRequest) bool {
+						return req.ProjectId == 1 &&
+							req.GitleaksCache.GithubSettingId == 2 &&
+							req.GitleaksCache.RepositoryFullName == "owner/repo" &&
+							req.GitleaksCache.ScanAt == scanAt.Unix()
+					})).
+					Return(&code.PutGitleaksCacheResponse{}, nil).
+					Once()
+			},
+		},
+		{
+			name: "return cache API error",
+			prepareMock: func(mockCode *mocks.CodeServiceClient) {
+				mockCode.
+					On("PutGitleaksCache", mock.Anything, mock.Anything).
+					Return(nil, errors.New("cache error")).
+					Once()
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCode := mocks.CodeServiceClient{}
+			tt.prepareMock(&mockCode)
+			s := sqsHandler{codeClient: &mockCode}
+
+			err := s.updateGitleaksCache(
+				context.Background(),
+				&message.CodeQueueMessage{ProjectID: 1, GitHubSettingID: 2},
+				&github.Repository{FullName: github.String("owner/repo")},
+				scanAt,
+			)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("updateGitleaksCache() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			mockCode.AssertExpectations(t)
+		})
+	}
+}
+
 func TestGetLastScannedAt(t *testing.T) {
 	type GetGitleaksCacheResponse struct {
 		Resp *code.GetGitleaksCacheResponse


### PR DESCRIPTION
## PRの概要

スキャン開始時にdatasource-apiが全子リポジトリをIN_PROGRESSへ初期化した後、各ワーカーが初回メッセージ受信時に同じ更新を繰り返していました。

初回配信時の重複したgRPC・DB更新と親ステータス再集計を削減するため、ワーカー側では初回のIN_PROGRESS更新を省略します。

GitleaksとCodeScanは、一時的なclone 404によるSQS再配信時に限り、ERRORから再試行中であることを示すためIN_PROGRESSへ戻します。
Dependencyは再配信対象外のため、ワーカー側のIN_PROGRESS更新を削除します。

| メッセージ | 変更前 | 変更後 |
|---|---|---|
| 初回配信 | datasource-apiとワーカーの両方でIN_PROGRESS更新 | datasource-apiのみでIN_PROGRESS更新 |
| Gitleaks／CodeScan再配信 | IN_PROGRESS更新 | IN_PROGRESS更新 |
| Dependency | ワーカーでもIN_PROGRESS更新 | datasource-apiのみでIN_PROGRESS更新 |

## レビュー観点例

- [ ] 初回配信ではdatasource-apiによる事前初期化を前提にして問題ない点
- [ ] Gitleaks／CodeScanの再配信時だけIN_PROGRESSへ戻す条件が適切な点
- [ ] Dependencyのワーカー側更新を削除してもステータス遷移が維持される点
- [ ] リポジトリ数に比例して発生していたgRPC・DB更新と親再集計を削減できる点