### PR TITLE
コードスキャンのリトライ状態を処理単位に分離

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,9 @@ require (
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.11.1
 	github.com/zricethezav/gitleaks/v8 v8.8.6
+	golang.org/x/sys v0.38.0
 	google.golang.org/grpc v1.77.0
+	google.golang.org/protobuf v1.36.10
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 )
 
@@ -181,12 +183,10 @@ require (
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.33.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251111163417-95abcf5c77ba // indirect
-	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/DataDog/dd-trace-go.v1 v1.74.8 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/pkg/codescan/handler.go
+++ b/pkg/codescan/handler.go
@@ -168,14 +168,18 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 		}
 
 		// Scan source code
-		scanResult, err := s.scanForRepository(ctx, r, token, gitHubSetting.BaseUrl)
+		scanCtx := ctx
+		if gitHubSetting.AuthMode == code.GitHubAuthModeGitHubApp {
+			scanCtx = githubcli.WithRepositoryNotFoundRetry(ctx)
+		}
+		scanResult, err := s.scanForRepository(scanCtx, r, token, gitHubSetting.BaseUrl)
 		if err != nil {
-			// Scan failed - update status to ERROR
 			s.logger.Errorf(ctx, "failed to codeScan scan: repository_name=%s, err=%+v", repoFullName, err)
-			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
 			if common.ShouldRetryGitHubAppRepositoryNotFound(gitHubSetting, err, receiveCount) {
+				s.updateRepositoryStatusRetryingWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName)
 				return semgrepFindings, successfullyScannedRepos, err
 			}
+			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
 			// Continue to next repository instead of returning error
 			continue
 		}
@@ -276,6 +280,12 @@ func (s *sqsHandler) getGitHubSetting(ctx context.Context, projectID, GitHubSett
 
 func (s *sqsHandler) updateRepositoryStatusInProgress(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName string) error {
 	return s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_IN_PROGRESS, "")
+}
+
+func (s *sqsHandler) updateRepositoryStatusRetryingWithWarn(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName string) {
+	if err := s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_IN_PROGRESS, common.GitHubAppRepositoryNotFoundRetryStatusDetail); err != nil {
+		s.logger.Warnf(ctx, "Failed to update repository status retrying: repository_name=%s, err=%+v", repositoryFullName, err)
+	}
 }
 
 func (s *sqsHandler) updateRepositoryStatusError(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName, statusDetail string) error {

--- a/pkg/codescan/handler_test.go
+++ b/pkg/codescan/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ca-risken/code/pkg/common"
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/datasource-api/proto/code"
 	"github.com/ca-risken/datasource-api/proto/code/mocks"
@@ -73,6 +74,35 @@ func TestFinalizeSkippedRepositoryStatus(t *testing.T) {
 			s := sqsHandler{codeClient: &mockCode, logger: logging.NewLogger()}
 
 			s.finalizeSkippedRepositoryStatus(context.Background(), 1, 2, tt.repo, tt.status, tt.statusDetail)
+
+			mockCode.AssertExpectations(t)
+		})
+	}
+}
+
+func TestUpdateRepositoryStatusRetrying(t *testing.T) {
+	cases := []struct {
+		name string
+	}{
+		{name: "keeps retryable failure in progress"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mockCode := mocks.CodeServiceClient{}
+			mockCode.
+				On("PutCodeScanRepository", mock.Anything, mock.MatchedBy(func(req *code.PutCodeScanRepositoryRequest) bool {
+					return req.ProjectId == 1 &&
+						req.CodeScanRepository.GithubSettingId == 2 &&
+						req.CodeScanRepository.RepositoryFullName == "owner/repo" &&
+						req.CodeScanRepository.Status == code.Status_IN_PROGRESS &&
+						req.CodeScanRepository.StatusDetail == common.GitHubAppRepositoryNotFoundRetryStatusDetail &&
+						req.CodeScanRepository.ScanAt > 0
+				})).
+				Return(&emptypb.Empty{}, nil).
+				Once()
+			s := sqsHandler{codeClient: &mockCode, logger: logging.NewLogger()}
+
+			s.updateRepositoryStatusRetryingWithWarn(context.Background(), 1, 2, "owner/repo")
 
 			mockCode.AssertExpectations(t)
 		})

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -15,6 +15,7 @@ import (
 )
 
 const MaxGitHubAppRepositoryNotFoundReceiveCount = 3
+const GitHubAppRepositoryNotFoundRetryStatusDetail = "Retrying: temporary GitHub authentication error"
 
 func FilterByNamePattern(repos []*github.Repository, pattern string) []*github.Repository {
 	var filteredRepos []*github.Repository

--- a/pkg/dependency/dependency.go
+++ b/pkg/dependency/dependency.go
@@ -133,10 +133,10 @@ func (t *trivyClient) retry(ctx context.Context, cloneURL, token, outputPath str
 		}
 		t.newRetryLogger(ctx, "trivy scan")(err, interval)
 		if waitErr := t.wait(ctx, interval); waitErr != nil {
-			return errors.Join(err, waitErr)
+			return fmt.Errorf("failed to wait before retrying trivy scan: %w", waitErr)
 		}
 		if resetErr := resetTrivyOutput(outputPath); resetErr != nil {
-			return errors.Join(err, resetErr)
+			return fmt.Errorf("failed to prepare trivy output for retry: %w", resetErr)
 		}
 		err = t.scan(ctx, cloneURL, token, outputPath)
 		if err == nil {

--- a/pkg/dependency/dependency.go
+++ b/pkg/dependency/dependency.go
@@ -157,9 +157,14 @@ func resetTrivyOutput(outputPath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to reset trivy output %s: %w", outputPath, err)
 	}
-	defer file.Close()
 	if err := file.Chmod(0600); err != nil {
-		return fmt.Errorf("failed to secure trivy output %s: %w", outputPath, err)
+		return errors.Join(
+			fmt.Errorf("failed to secure trivy output %s: %w", outputPath, err),
+			file.Close(),
+		)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("failed to close trivy output %s: %w", outputPath, err)
 	}
 	return nil
 }

--- a/pkg/dependency/dependency.go
+++ b/pkg/dependency/dependency.go
@@ -108,39 +108,28 @@ func (t *trivyClient) Scan(ctx context.Context, cloneURL, token string, outputPa
 	if err == nil {
 		return nil
 	}
-	if retryRepositoryNotFound && errors.Is(err, gittransport.ErrRepositoryNotFound) {
-		return t.retryRepositoryNotFound(ctx, cloneURL, token, outputPath, err)
-	}
-	return t.retryWithExponentialBackOff(ctx, cloneURL, token, outputPath, err, retryRepositoryNotFound)
+	return t.retry(ctx, cloneURL, token, outputPath, err, retryRepositoryNotFound)
 }
 
-func (t *trivyClient) retryRepositoryNotFound(ctx context.Context, cloneURL, token, outputPath string, initialErr error) error {
-	err := initialErr
-	for _, interval := range gitHubAppRepositoryNotFoundRetryIntervals {
-		t.newRetryLogger(ctx, "trivy scan")(err, interval)
-		if waitErr := t.wait(ctx, interval); waitErr != nil {
-			return waitErr
-		}
-		if cleanErr := cleanTrivyOutput(outputPath); cleanErr != nil {
-			return cleanErr
-		}
-		err = t.scan(ctx, cloneURL, token, outputPath)
-		if err == nil {
-			return nil
-		}
-		if !errors.Is(err, gittransport.ErrRepositoryNotFound) {
-			return err
-		}
-	}
-	return err
-}
-
-func (t *trivyClient) retryWithExponentialBackOff(ctx context.Context, cloneURL, token, outputPath string, initialErr error, retryRepositoryNotFound bool) error {
+func (t *trivyClient) retry(ctx context.Context, cloneURL, token, outputPath string, initialErr error, retryRepositoryNotFound bool) error {
 	err := initialErr
 	retryer := backoff.NewExponentialBackOff()
 	retryer.Reset()
+	repositoryNotFoundRetryIndex := 0
 	for range t.retryNum {
-		interval := retryer.NextBackOff()
+		var interval time.Duration
+		if retryRepositoryNotFound && errors.Is(err, gittransport.ErrRepositoryNotFound) {
+			if repositoryNotFoundRetryIndex >= len(gitHubAppRepositoryNotFoundRetryIntervals) {
+				break
+			}
+			interval = gitHubAppRepositoryNotFoundRetryIntervals[repositoryNotFoundRetryIndex]
+			repositoryNotFoundRetryIndex++
+		} else {
+			interval = retryer.NextBackOff()
+			if interval == backoff.Stop {
+				break
+			}
+		}
 		t.newRetryLogger(ctx, "trivy scan")(err, interval)
 		if waitErr := t.wait(ctx, interval); waitErr != nil {
 			return waitErr
@@ -151,9 +140,6 @@ func (t *trivyClient) retryWithExponentialBackOff(ctx context.Context, cloneURL,
 		err = t.scan(ctx, cloneURL, token, outputPath)
 		if err == nil {
 			return nil
-		}
-		if retryRepositoryNotFound && errors.Is(err, gittransport.ErrRepositoryNotFound) {
-			return t.retryRepositoryNotFound(ctx, cloneURL, token, outputPath, err)
 		}
 	}
 	return err

--- a/pkg/dependency/dependency.go
+++ b/pkg/dependency/dependency.go
@@ -16,11 +16,7 @@ import (
 	trivytypes "github.com/aquasecurity/trivy/pkg/types"
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/cenkalti/backoff/v4"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/config"
 	gittransport "github.com/go-git/go-git/v5/plumbing/transport"
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
-	"github.com/go-git/go-git/v5/storage/memory"
 	"golang.org/x/sys/unix"
 )
 
@@ -55,7 +51,6 @@ type trivyClient struct {
 	retryNum  uint64
 	logger    logging.Logger
 	wait      func(context.Context, time.Duration) error
-	checkRepo func(context.Context, string, string) error
 }
 
 func newTrivyClient(trivyPath string, exec exec.Interface, retryNum *uint64, l logging.Logger) trivyScanner {
@@ -69,7 +64,6 @@ func newTrivyClient(trivyPath string, exec exec.Interface, retryNum *uint64, l l
 		retryNum:  retry,
 		logger:    l,
 		wait:      waitForTrivyRetry,
-		checkRepo: checkRepository,
 	}
 }
 
@@ -154,6 +148,9 @@ func (t *trivyClient) retry(ctx context.Context, cloneURL, token, outputPath str
 
 func resetTrivyOutput(outputPath string) error {
 	fd, err := unix.Open(outputPath, unix.O_WRONLY|unix.O_TRUNC|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0600)
+	if errors.Is(err, unix.ENOENT) {
+		fd, err = unix.Open(outputPath, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0600)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to reset trivy output %s: %w", outputPath, err)
 	}
@@ -188,31 +185,15 @@ func (t *trivyClient) scan(ctx context.Context, cloneURL, token string, outputPa
 	err := cmd.Run()
 	if err != nil {
 		if isRepositoryNotFoundOutput(stderr.String()) {
-			if checkErr := t.checkRepo(ctx, token, cloneURL); errors.Is(checkErr, gittransport.ErrRepositoryNotFound) {
-				return fmt.Errorf(
-					"failed to execute trivy for %s: %w",
-					cloneURL,
-					errors.Join(err, gittransport.ErrRepositoryNotFound),
-				)
-			}
+			return fmt.Errorf(
+				"failed to execute trivy for %s: %w",
+				cloneURL,
+				errors.Join(err, gittransport.ErrRepositoryNotFound),
+			)
 		}
 		return fmt.Errorf("failed to execute trivy: err=%w, cloneURL=%s", err, cloneURL)
 	}
 	return nil
-}
-
-func checkRepository(ctx context.Context, token, cloneURL string) error {
-	remote := git.NewRemote(memory.NewStorage(), &config.RemoteConfig{
-		Name: "origin",
-		URLs: []string{cloneURL},
-	})
-	_, err := remote.ListContext(ctx, &git.ListOptions{
-		Auth: &http.BasicAuth{
-			Username: "dummy", // anything except an empty string
-			Password: token,
-		},
-	})
-	return err
 }
 
 func isRepositoryNotFoundOutput(output string) bool {

--- a/pkg/dependency/dependency.go
+++ b/pkg/dependency/dependency.go
@@ -21,6 +21,7 @@ import (
 	gittransport "github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/storage/memory"
+	"golang.org/x/sys/unix"
 )
 
 const RETRY_NUM uint64 = 3
@@ -152,16 +153,16 @@ func (t *trivyClient) retry(ctx context.Context, cloneURL, token, outputPath str
 }
 
 func resetTrivyOutput(outputPath string) error {
-	info, err := os.Lstat(outputPath)
-	if err != nil {
-		return fmt.Errorf("failed to inspect trivy output %s: %w", outputPath, err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("refusing to reset symlinked trivy output: %s", outputPath)
-	}
-	file, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_TRUNC, 0600)
+	fd, err := unix.Open(outputPath, unix.O_WRONLY|unix.O_TRUNC|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to reset trivy output %s: %w", outputPath, err)
+	}
+	file := os.NewFile(uintptr(fd), outputPath)
+	if file == nil {
+		if closeErr := unix.Close(fd); closeErr != nil {
+			return fmt.Errorf("failed to open trivy output %s: %w", outputPath, closeErr)
+		}
+		return fmt.Errorf("failed to open trivy output %s", outputPath)
 	}
 	if err := file.Chmod(0600); err != nil {
 		return errors.Join(
@@ -188,7 +189,11 @@ func (t *trivyClient) scan(ctx context.Context, cloneURL, token string, outputPa
 	if err != nil {
 		if isRepositoryNotFoundOutput(stderr.String()) {
 			if checkErr := t.checkRepo(ctx, token, cloneURL); errors.Is(checkErr, gittransport.ErrRepositoryNotFound) {
-				return fmt.Errorf("failed to execute trivy: err=%v, cloneURL=%s: %w", err, cloneURL, gittransport.ErrRepositoryNotFound)
+				return fmt.Errorf(
+					"failed to execute trivy for %s: %w",
+					cloneURL,
+					errors.Join(err, gittransport.ErrRepositoryNotFound),
+				)
 			}
 		}
 		return fmt.Errorf("failed to execute trivy: err=%w, cloneURL=%s", err, cloneURL)

--- a/pkg/dependency/dependency.go
+++ b/pkg/dependency/dependency.go
@@ -132,10 +132,10 @@ func (t *trivyClient) retry(ctx context.Context, cloneURL, token, outputPath str
 		}
 		t.newRetryLogger(ctx, "trivy scan")(err, interval)
 		if waitErr := t.wait(ctx, interval); waitErr != nil {
-			return waitErr
+			return errors.Join(err, waitErr)
 		}
-		if cleanErr := cleanTrivyOutput(outputPath); cleanErr != nil {
-			return cleanErr
+		if resetErr := resetTrivyOutput(outputPath); resetErr != nil {
+			return errors.Join(err, resetErr)
 		}
 		err = t.scan(ctx, cloneURL, token, outputPath)
 		if err == nil {
@@ -145,9 +145,21 @@ func (t *trivyClient) retry(ctx context.Context, cloneURL, token, outputPath str
 	return err
 }
 
-func cleanTrivyOutput(outputPath string) error {
-	if err := os.Remove(outputPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to clean trivy output %s: %w", outputPath, err)
+func resetTrivyOutput(outputPath string) error {
+	info, err := os.Lstat(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to inspect trivy output %s: %w", outputPath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to reset symlinked trivy output: %s", outputPath)
+	}
+	file, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to reset trivy output %s: %w", outputPath, err)
+	}
+	defer file.Close()
+	if err := file.Chmod(0600); err != nil {
+		return fmt.Errorf("failed to secure trivy output %s: %w", outputPath, err)
 	}
 	return nil
 }
@@ -163,12 +175,22 @@ func (t *trivyClient) scan(ctx context.Context, cloneURL, token string, outputPa
 	cmd.SetStderr(&stderr)
 	err := cmd.Run()
 	if err != nil {
-		if strings.Contains(strings.ToLower(stderr.String()), "repository not found") {
+		if isRepositoryNotFoundOutput(stderr.String()) {
 			return fmt.Errorf("failed to execute trivy: err=%v, cloneURL=%s: %w", err, cloneURL, gittransport.ErrRepositoryNotFound)
 		}
 		return fmt.Errorf("failed to execute trivy: err=%w, cloneURL=%s", err, cloneURL)
 	}
 	return nil
+}
+
+func isRepositoryNotFoundOutput(output string) bool {
+	for _, line := range strings.Split(strings.ToLower(output), "\n") {
+		normalized := strings.TrimSuffix(strings.TrimSpace(line), ".")
+		if normalized == "repository not found" || strings.HasSuffix(normalized, ": repository not found") {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *trivyClient) newRetryLogger(ctx context.Context, funcName string) func(error, time.Duration) {

--- a/pkg/dependency/dependency.go
+++ b/pkg/dependency/dependency.go
@@ -16,7 +16,11 @@ import (
 	trivytypes "github.com/aquasecurity/trivy/pkg/types"
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/cenkalti/backoff/v4"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	gittransport "github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-git/go-git/v5/storage/memory"
 )
 
 const RETRY_NUM uint64 = 3
@@ -50,6 +54,7 @@ type trivyClient struct {
 	retryNum  uint64
 	logger    logging.Logger
 	wait      func(context.Context, time.Duration) error
+	checkRepo func(context.Context, string, string) error
 }
 
 func newTrivyClient(trivyPath string, exec exec.Interface, retryNum *uint64, l logging.Logger) trivyScanner {
@@ -63,6 +68,7 @@ func newTrivyClient(trivyPath string, exec exec.Interface, retryNum *uint64, l l
 		retryNum:  retry,
 		logger:    l,
 		wait:      waitForTrivyRetry,
+		checkRepo: checkRepository,
 	}
 }
 
@@ -181,11 +187,27 @@ func (t *trivyClient) scan(ctx context.Context, cloneURL, token string, outputPa
 	err := cmd.Run()
 	if err != nil {
 		if isRepositoryNotFoundOutput(stderr.String()) {
-			return fmt.Errorf("failed to execute trivy: err=%v, cloneURL=%s: %w", err, cloneURL, gittransport.ErrRepositoryNotFound)
+			if checkErr := t.checkRepo(ctx, token, cloneURL); errors.Is(checkErr, gittransport.ErrRepositoryNotFound) {
+				return fmt.Errorf("failed to execute trivy: err=%v, cloneURL=%s: %w", err, cloneURL, gittransport.ErrRepositoryNotFound)
+			}
 		}
 		return fmt.Errorf("failed to execute trivy: err=%w, cloneURL=%s", err, cloneURL)
 	}
 	return nil
+}
+
+func checkRepository(ctx context.Context, token, cloneURL string) error {
+	remote := git.NewRemote(memory.NewStorage(), &config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{cloneURL},
+	})
+	_, err := remote.ListContext(ctx, &git.ListOptions{
+		Auth: &http.BasicAuth{
+			Username: "dummy", // anything except an empty string
+			Password: token,
+		},
+	})
+	return err
 }
 
 func isRepositoryNotFoundOutput(output string) bool {

--- a/pkg/dependency/dependency.go
+++ b/pkg/dependency/dependency.go
@@ -178,9 +178,9 @@ func (t *trivyClient) scan(ctx context.Context, cloneURL, token string, outputPa
 	err := cmd.Run()
 	if err != nil {
 		if strings.Contains(strings.ToLower(stderr.String()), "repository not found") {
-			return fmt.Errorf("failed to execute trivy: err=%v, cloneURL=%s, stderr=%s: %w", err, cloneURL, stderr.String(), gittransport.ErrRepositoryNotFound)
+			return fmt.Errorf("failed to execute trivy: err=%v, cloneURL=%s: %w", err, cloneURL, gittransport.ErrRepositoryNotFound)
 		}
-		return fmt.Errorf("failed to execute trivy: err=%w, cloneURL=%s, stderr=%s", err, cloneURL, stderr.String())
+		return fmt.Errorf("failed to execute trivy: err=%w, cloneURL=%s", err, cloneURL)
 	}
 	return nil
 }

--- a/pkg/dependency/dependency.go
+++ b/pkg/dependency/dependency.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"k8s.io/utils/exec"
@@ -14,12 +16,19 @@ import (
 	trivytypes "github.com/aquasecurity/trivy/pkg/types"
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/cenkalti/backoff/v4"
+	gittransport "github.com/go-git/go-git/v5/plumbing/transport"
 )
 
 const RETRY_NUM uint64 = 3
 
+var gitHubAppRepositoryNotFoundRetryIntervals = []time.Duration{
+	3 * time.Second,
+	10 * time.Second,
+	30 * time.Second,
+}
+
 type dependencyServiceClient interface {
-	getResult(ctx context.Context, cloneURL, token, outputPath string) (*trivytypes.Report, error)
+	getResult(ctx context.Context, cloneURL, token, outputPath string, retryRepositoryNotFound bool) (*trivytypes.Report, error)
 }
 
 type dependencyConfig struct {
@@ -32,14 +41,15 @@ type dependencyClient struct {
 }
 
 type trivyScanner interface {
-	Scan(ctx context.Context, cloneURL, token, outputPath string) error
+	Scan(ctx context.Context, cloneURL, token, outputPath string, retryRepositoryNotFound bool) error
 }
 
 type trivyClient struct {
 	trivyPath string
 	exec      exec.Interface
-	retryer   backoff.BackOff
+	retryNum  uint64
 	logger    logging.Logger
+	wait      func(context.Context, time.Duration) error
 }
 
 func newTrivyClient(trivyPath string, exec exec.Interface, retryNum *uint64, l logging.Logger) trivyScanner {
@@ -50,8 +60,9 @@ func newTrivyClient(trivyPath string, exec exec.Interface, retryNum *uint64, l l
 	return &trivyClient{
 		trivyPath: trivyPath,
 		exec:      exec,
-		retryer:   backoff.WithMaxRetries(backoff.NewExponentialBackOff(), retry),
+		retryNum:  retry,
 		logger:    l,
+		wait:      waitForTrivyRetry,
 	}
 }
 
@@ -62,9 +73,9 @@ func newDependencyClient(conf *dependencyConfig, l logging.Logger) dependencySer
 	}
 }
 
-func (d *dependencyClient) getResult(ctx context.Context, cloneURL, token, outputPath string) (*trivytypes.Report, error) {
+func (d *dependencyClient) getResult(ctx context.Context, cloneURL, token, outputPath string, retryRepositoryNotFound bool) (*trivytypes.Report, error) {
 	defer os.Remove(outputPath)
-	err := d.trivy.Scan(ctx, cloneURL, token, outputPath)
+	err := d.trivy.Scan(ctx, cloneURL, token, outputPath, retryRepositoryNotFound)
 	if err != nil {
 		return nil, err
 	}
@@ -81,11 +92,78 @@ func (d *dependencyClient) getResult(ctx context.Context, cloneURL, token, outpu
 	return &dependency, nil
 }
 
-func (t *trivyClient) Scan(ctx context.Context, cloneURL, token string, outputPath string) error {
-	operation := func() error {
-		return t.scan(ctx, cloneURL, token, outputPath)
+func waitForTrivyRetry(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
 	}
-	return backoff.RetryNotify(operation, t.retryer, t.newRetryLogger(ctx, "trivy scan"))
+}
+
+func (t *trivyClient) Scan(ctx context.Context, cloneURL, token string, outputPath string, retryRepositoryNotFound bool) error {
+	err := t.scan(ctx, cloneURL, token, outputPath)
+	if err == nil {
+		return nil
+	}
+	if retryRepositoryNotFound && errors.Is(err, gittransport.ErrRepositoryNotFound) {
+		return t.retryRepositoryNotFound(ctx, cloneURL, token, outputPath, err)
+	}
+	return t.retryWithExponentialBackOff(ctx, cloneURL, token, outputPath, err, retryRepositoryNotFound)
+}
+
+func (t *trivyClient) retryRepositoryNotFound(ctx context.Context, cloneURL, token, outputPath string, initialErr error) error {
+	err := initialErr
+	for _, interval := range gitHubAppRepositoryNotFoundRetryIntervals {
+		t.newRetryLogger(ctx, "trivy scan")(err, interval)
+		if waitErr := t.wait(ctx, interval); waitErr != nil {
+			return waitErr
+		}
+		if cleanErr := cleanTrivyOutput(outputPath); cleanErr != nil {
+			return cleanErr
+		}
+		err = t.scan(ctx, cloneURL, token, outputPath)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, gittransport.ErrRepositoryNotFound) {
+			return err
+		}
+	}
+	return err
+}
+
+func (t *trivyClient) retryWithExponentialBackOff(ctx context.Context, cloneURL, token, outputPath string, initialErr error, retryRepositoryNotFound bool) error {
+	err := initialErr
+	retryer := backoff.NewExponentialBackOff()
+	retryer.Reset()
+	for range t.retryNum {
+		interval := retryer.NextBackOff()
+		t.newRetryLogger(ctx, "trivy scan")(err, interval)
+		if waitErr := t.wait(ctx, interval); waitErr != nil {
+			return waitErr
+		}
+		if cleanErr := cleanTrivyOutput(outputPath); cleanErr != nil {
+			return cleanErr
+		}
+		err = t.scan(ctx, cloneURL, token, outputPath)
+		if err == nil {
+			return nil
+		}
+		if retryRepositoryNotFound && errors.Is(err, gittransport.ErrRepositoryNotFound) {
+			return t.retryRepositoryNotFound(ctx, cloneURL, token, outputPath, err)
+		}
+	}
+	return err
+}
+
+func cleanTrivyOutput(outputPath string) error {
+	if err := os.Remove(outputPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to clean trivy output %s: %w", outputPath, err)
+	}
+	return nil
 }
 
 func (t *trivyClient) scan(ctx context.Context, cloneURL, token string, outputPath string) error {
@@ -99,7 +177,10 @@ func (t *trivyClient) scan(ctx context.Context, cloneURL, token string, outputPa
 	cmd.SetStderr(&stderr)
 	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("failed to execute trivy: err=%w, cloneURL=%s", err, cloneURL)
+		if strings.Contains(strings.ToLower(stderr.String()), "repository not found") {
+			return fmt.Errorf("failed to execute trivy: err=%v, cloneURL=%s, stderr=%s: %w", err, cloneURL, stderr.String(), gittransport.ErrRepositoryNotFound)
+		}
+		return fmt.Errorf("failed to execute trivy: err=%w, cloneURL=%s, stderr=%s", err, cloneURL, stderr.String())
 	}
 	return nil
 }

--- a/pkg/dependency/dependency_test.go
+++ b/pkg/dependency/dependency_test.go
@@ -235,6 +235,14 @@ func TestScanGitHubAppRepositoryNotFoundRetry(t *testing.T) {
 			wantErr:      true,
 			wantAttempts: 4,
 		},
+		{
+			name:         "switches to repository not found without resetting retry budget",
+			errorOutputs: []string{"scanner initialization failed", "Repository not found", "Repository not found", "Repository not found"},
+			runErrors:    []error{errors.New("exit 1"), errors.New("exit 1"), errors.New("exit 1"), errors.New("exit 1")},
+			wantErr:      true,
+			wantAttempts: 4,
+			wantRepoErr:  true,
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/dependency/dependency_test.go
+++ b/pkg/dependency/dependency_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -259,9 +260,6 @@ func TestScanGitHubAppRepositoryNotFoundRetry(t *testing.T) {
 			}
 			client := newTrivyClient("trivy", fakeExec, nil, logging.NewLogger()).(*trivyClient)
 			client.wait = func(context.Context, time.Duration) error { return nil }
-			client.checkRepo = func(context.Context, string, string) error {
-				return gittransport.ErrRepositoryNotFound
-			}
 
 			err := client.Scan(context.Background(), "https://github.com/owner/repo.git", "token", filepathForTest(t), true)
 			if c.wantErr && err == nil {
@@ -292,9 +290,6 @@ func TestScanRetryPreservesRepositoryNotFoundClassification(t *testing.T) {
 
 	client := newTrivyClient("trivy", fakeExec, nil, logging.NewLogger()).(*trivyClient)
 	client.wait = func(context.Context, time.Duration) error { return context.Canceled }
-	client.checkRepo = func(context.Context, string, string) error {
-		return gittransport.ErrRepositoryNotFound
-	}
 
 	err := client.Scan(context.Background(), "https://github.com/owner/repo.git", "token", filepathForTest(t), true)
 	if !errors.Is(err, gittransport.ErrRepositoryNotFound) {
@@ -305,32 +300,17 @@ func TestScanRetryPreservesRepositoryNotFoundClassification(t *testing.T) {
 	}
 }
 
-func TestScanVerifiesRepositoryNotFound(t *testing.T) {
+func TestScanClassifiesRepositoryNotFound(t *testing.T) {
 	trivyErr := errors.New("trivy exited")
 	cases := []struct {
-		name           string
-		errorOutput    string
-		checkErr       error
-		wantRepoErr    bool
-		wantCheckCalls int
+		name        string
+		errorOutput string
+		wantRepoErr bool
 	}{
 		{
-			name:           "classifies typed repository not found",
-			errorOutput:    "remote: Repository not found.",
-			checkErr:       gittransport.ErrRepositoryNotFound,
-			wantRepoErr:    true,
-			wantCheckCalls: 1,
-		},
-		{
-			name:           "does not classify when repository is reachable",
-			errorOutput:    "remote: Repository not found.",
-			wantCheckCalls: 1,
-		},
-		{
-			name:           "does not classify another authentication error",
-			errorOutput:    "remote: Repository not found.",
-			checkErr:       errors.New("authentication failed"),
-			wantCheckCalls: 1,
+			name:        "classifies strict repository not found line",
+			errorOutput: "remote: Repository not found.",
+			wantRepoErr: true,
 		},
 		{
 			name:        "does not verify unrelated trivy error",
@@ -351,11 +331,6 @@ func TestScanVerifiesRepositoryNotFound(t *testing.T) {
 
 			retryNum := uint64(0)
 			client := newTrivyClient("trivy", fakeExec, &retryNum, logging.NewLogger()).(*trivyClient)
-			checkCalls := 0
-			client.checkRepo = func(context.Context, string, string) error {
-				checkCalls++
-				return c.checkErr
-			}
 
 			err := client.Scan(context.Background(), "https://github.com/owner/repo.git", "token", filepathForTest(t), true)
 			if err == nil {
@@ -366,9 +341,6 @@ func TestScanVerifiesRepositoryNotFound(t *testing.T) {
 			}
 			if !errors.Is(err, trivyErr) {
 				t.Fatalf("Scan() error = %v, want original trivy error", err)
-			}
-			if checkCalls != c.wantCheckCalls {
-				t.Fatalf("repository check calls = %d, want %d", checkCalls, c.wantCheckCalls)
 			}
 		})
 	}
@@ -402,6 +374,12 @@ func TestResetTrivyOutput(t *testing.T) {
 				return link
 			},
 			wantErr: true,
+		},
+		{
+			name: "recreates missing file",
+			prepare: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "missing.json")
+			},
 		},
 	}
 

--- a/pkg/dependency/dependency_test.go
+++ b/pkg/dependency/dependency_test.go
@@ -259,6 +259,9 @@ func TestScanGitHubAppRepositoryNotFoundRetry(t *testing.T) {
 			}
 			client := newTrivyClient("trivy", fakeExec, nil, logging.NewLogger()).(*trivyClient)
 			client.wait = func(context.Context, time.Duration) error { return nil }
+			client.checkRepo = func(context.Context, string, string) error {
+				return gittransport.ErrRepositoryNotFound
+			}
 
 			err := client.Scan(context.Background(), "https://github.com/owner/repo.git", "token", filepathForTest(t), true)
 			if c.wantErr && err == nil {
@@ -289,6 +292,9 @@ func TestScanRetryPreservesRepositoryNotFoundClassification(t *testing.T) {
 
 	client := newTrivyClient("trivy", fakeExec, nil, logging.NewLogger()).(*trivyClient)
 	client.wait = func(context.Context, time.Duration) error { return context.Canceled }
+	client.checkRepo = func(context.Context, string, string) error {
+		return gittransport.ErrRepositoryNotFound
+	}
 
 	err := client.Scan(context.Background(), "https://github.com/owner/repo.git", "token", filepathForTest(t), true)
 	if !errors.Is(err, gittransport.ErrRepositoryNotFound) {
@@ -296,6 +302,71 @@ func TestScanRetryPreservesRepositoryNotFoundClassification(t *testing.T) {
 	}
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Scan() error = %v, want context canceled", err)
+	}
+}
+
+func TestScanVerifiesRepositoryNotFound(t *testing.T) {
+	cases := []struct {
+		name           string
+		errorOutput    string
+		checkErr       error
+		wantRepoErr    bool
+		wantCheckCalls int
+	}{
+		{
+			name:           "classifies typed repository not found",
+			errorOutput:    "remote: Repository not found.",
+			checkErr:       gittransport.ErrRepositoryNotFound,
+			wantRepoErr:    true,
+			wantCheckCalls: 1,
+		},
+		{
+			name:           "does not classify when repository is reachable",
+			errorOutput:    "remote: Repository not found.",
+			wantCheckCalls: 1,
+		},
+		{
+			name:           "does not classify another authentication error",
+			errorOutput:    "remote: Repository not found.",
+			checkErr:       errors.New("authentication failed"),
+			wantCheckCalls: 1,
+		},
+		{
+			name:        "does not verify unrelated trivy error",
+			errorOutput: "scanner initialization failed",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fakeExec := &fakeexec.FakeExec{}
+			fakeCmd := &fakeexec.FakeCmd{}
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			fakeCmd.Stdout = &stdout
+			fakeCmd.Stderr = &stderr
+			fakeExec.CommandScript = append(fakeExec.CommandScript, makeFakeCmd(fakeCmd, "trivy"))
+			fakeCmd.RunScript = append(fakeCmd.RunScript, makeFakeOutput("", c.errorOutput, errors.New("exit 1")))
+
+			retryNum := uint64(0)
+			client := newTrivyClient("trivy", fakeExec, &retryNum, logging.NewLogger()).(*trivyClient)
+			checkCalls := 0
+			client.checkRepo = func(context.Context, string, string) error {
+				checkCalls++
+				return c.checkErr
+			}
+
+			err := client.Scan(context.Background(), "https://github.com/owner/repo.git", "token", filepathForTest(t), true)
+			if err == nil {
+				t.Fatal("Scan() error = nil, want error")
+			}
+			if got := errors.Is(err, gittransport.ErrRepositoryNotFound); got != c.wantRepoErr {
+				t.Fatalf("Scan() repository not found = %v, want %v; err=%v", got, c.wantRepoErr, err)
+			}
+			if checkCalls != c.wantCheckCalls {
+				t.Fatalf("repository check calls = %d, want %d", checkCalls, c.wantCheckCalls)
+			}
+		})
 	}
 }
 

--- a/pkg/dependency/dependency_test.go
+++ b/pkg/dependency/dependency_test.go
@@ -277,6 +277,108 @@ func TestScanGitHubAppRepositoryNotFoundRetry(t *testing.T) {
 	}
 }
 
+func TestScanRetryPreservesRepositoryNotFoundClassification(t *testing.T) {
+	fakeExec := &fakeexec.FakeExec{}
+	fakeCmd := &fakeexec.FakeCmd{}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	fakeCmd.Stdout = &stdout
+	fakeCmd.Stderr = &stderr
+	fakeExec.CommandScript = append(fakeExec.CommandScript, makeFakeCmd(fakeCmd, "trivy"))
+	fakeCmd.RunScript = append(fakeCmd.RunScript, makeFakeOutput("", "Repository not found", errors.New("exit 1")))
+
+	client := newTrivyClient("trivy", fakeExec, nil, logging.NewLogger()).(*trivyClient)
+	client.wait = func(context.Context, time.Duration) error { return context.Canceled }
+
+	err := client.Scan(context.Background(), "https://github.com/owner/repo.git", "token", filepathForTest(t), true)
+	if !errors.Is(err, gittransport.ErrRepositoryNotFound) {
+		t.Fatalf("Scan() error = %v, want repository not found classification", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Scan() error = %v, want context canceled", err)
+	}
+}
+
+func TestResetTrivyOutput(t *testing.T) {
+	cases := []struct {
+		name    string
+		prepare func(*testing.T) string
+		wantErr bool
+	}{
+		{
+			name: "truncates existing file and keeps private permissions",
+			prepare: func(t *testing.T) string {
+				path := filepathForTest(t)
+				if err := os.WriteFile(path, []byte("partial"), 0644); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+				return path
+			},
+		},
+		{
+			name: "rejects symlink",
+			prepare: func(t *testing.T) string {
+				target := filepathForTest(t)
+				link := target + "-link"
+				if err := os.Symlink(target, link); err != nil {
+					t.Fatalf("Symlink() error = %v", err)
+				}
+				t.Cleanup(func() { os.Remove(link) })
+				return link
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			path := c.prepare(t)
+			err := resetTrivyOutput(path)
+			if c.wantErr {
+				if err == nil {
+					t.Fatal("resetTrivyOutput() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resetTrivyOutput() error = %v", err)
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("Stat() error = %v", err)
+			}
+			if info.Size() != 0 {
+				t.Fatalf("resetTrivyOutput() size = %d, want 0", info.Size())
+			}
+			if got := info.Mode().Perm(); got != 0600 {
+				t.Fatalf("resetTrivyOutput() permissions = %o, want 600", got)
+			}
+		})
+	}
+}
+
+func TestIsRepositoryNotFoundOutput(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{name: "exact message", output: "Repository not found.", want: true},
+		{name: "prefixed message", output: "failed to clone: Repository not found.", want: true},
+		{name: "multiple lines", output: "diagnostic\nremote: Repository not found.\n", want: true},
+		{name: "phrase embedded in diagnostic", output: "repository not found while parsing a local file path", want: false},
+		{name: "unrelated", output: "scanner initialization failed", want: false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isRepositoryNotFoundOutput(c.output); got != c.want {
+				t.Fatalf("isRepositoryNotFoundOutput(%q) = %v, want %v", c.output, got, c.want)
+			}
+		})
+	}
+}
+
 func filepathForTest(t *testing.T) string {
 	t.Helper()
 	f, err := os.CreateTemp("", "dependency-retry-*.json")

--- a/pkg/dependency/dependency_test.go
+++ b/pkg/dependency/dependency_test.go
@@ -306,6 +306,7 @@ func TestScanRetryPreservesRepositoryNotFoundClassification(t *testing.T) {
 }
 
 func TestScanVerifiesRepositoryNotFound(t *testing.T) {
+	trivyErr := errors.New("trivy exited")
 	cases := []struct {
 		name           string
 		errorOutput    string
@@ -346,7 +347,7 @@ func TestScanVerifiesRepositoryNotFound(t *testing.T) {
 			fakeCmd.Stdout = &stdout
 			fakeCmd.Stderr = &stderr
 			fakeExec.CommandScript = append(fakeExec.CommandScript, makeFakeCmd(fakeCmd, "trivy"))
-			fakeCmd.RunScript = append(fakeCmd.RunScript, makeFakeOutput("", c.errorOutput, errors.New("exit 1")))
+			fakeCmd.RunScript = append(fakeCmd.RunScript, makeFakeOutput("", c.errorOutput, trivyErr))
 
 			retryNum := uint64(0)
 			client := newTrivyClient("trivy", fakeExec, &retryNum, logging.NewLogger()).(*trivyClient)
@@ -362,6 +363,9 @@ func TestScanVerifiesRepositoryNotFound(t *testing.T) {
 			}
 			if got := errors.Is(err, gittransport.ErrRepositoryNotFound); got != c.wantRepoErr {
 				t.Fatalf("Scan() repository not found = %v, want %v; err=%v", got, c.wantRepoErr, err)
+			}
+			if !errors.Is(err, trivyErr) {
+				t.Fatalf("Scan() error = %v, want original trivy error", err)
 			}
 			if checkCalls != c.wantCheckCalls {
 				t.Fatalf("repository check calls = %d, want %d", checkCalls, c.wantCheckCalls)

--- a/pkg/dependency/dependency_test.go
+++ b/pkg/dependency/dependency_test.go
@@ -8,9 +8,11 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	trivytypes "github.com/aquasecurity/trivy/pkg/types"
 	"github.com/ca-risken/common/pkg/logging"
+	gittransport "github.com/go-git/go-git/v5/plumbing/transport"
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
 )
@@ -19,7 +21,7 @@ type fakeTrivyClient struct {
 	err error
 }
 
-func (f *fakeTrivyClient) Scan(ctx context.Context, cloneURL, token, filePath string) error {
+func (f *fakeTrivyClient) Scan(ctx context.Context, cloneURL, token, filePath string, retryRepositoryNotFound bool) error {
 	return f.err
 }
 
@@ -119,7 +121,7 @@ func TestGetResult(t *testing.T) {
 				t.Fatalf("Failed to close test result file. err: %+v", err)
 			}
 			defer os.Remove(f.Name())
-			got, err := client.getResult(ctx, c.cloneURL, c.token, f.Name())
+			got, err := client.getResult(ctx, c.cloneURL, c.token, f.Name(), false)
 			if c.wantErr && err == nil {
 				t.Fatal("Unexpected no error")
 			}
@@ -184,7 +186,7 @@ func TestScan(t *testing.T) {
 
 			retryNum := uint64(0)
 			client := newTrivyClient("trivyPath", fakeExec, &retryNum, logging.NewLogger())
-			err := client.Scan(ctx, c.cloneURL, c.token, c.filePath)
+			err := client.Scan(ctx, c.cloneURL, c.token, c.filePath, false)
 			if c.wantErr && err == nil {
 				t.Fatal("Unexpected no error")
 			}
@@ -196,6 +198,84 @@ func TestScan(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestScanGitHubAppRepositoryNotFoundRetry(t *testing.T) {
+	cases := []struct {
+		name         string
+		errorOutputs []string
+		runErrors    []error
+		wantErr      bool
+		wantAttempts int
+		wantRepoErr  bool
+	}{
+		{
+			name:         "recovers after repository not found",
+			errorOutputs: []string{"Repository not found", "Repository not found", ""},
+			runErrors:    []error{errors.New("exit 1"), errors.New("exit 1"), nil},
+			wantAttempts: 3,
+		},
+		{
+			name:         "exhausts repository not found retries",
+			errorOutputs: []string{"Repository not found", "Repository not found", "Repository not found", "Repository not found"},
+			runErrors:    []error{errors.New("exit 1"), errors.New("exit 1"), errors.New("exit 1"), errors.New("exit 1")},
+			wantErr:      true,
+			wantAttempts: 4,
+			wantRepoErr:  true,
+		},
+		{
+			name:         "keeps short retries for other errors",
+			errorOutputs: []string{"scanner initialization failed", "scanner initialization failed", "scanner initialization failed", "scanner initialization failed"},
+			runErrors:    []error{errors.New("exit 1"), errors.New("exit 1"), errors.New("exit 1"), errors.New("exit 1")},
+			wantErr:      true,
+			wantAttempts: 4,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fakeExec := &fakeexec.FakeExec{}
+			fakeCmd := &fakeexec.FakeCmd{}
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			fakeCmd.Stdout = &stdout
+			fakeCmd.Stderr = &stderr
+			for i := range c.runErrors {
+				fakeExec.CommandScript = append(fakeExec.CommandScript, makeFakeCmd(fakeCmd, "trivy"))
+				fakeCmd.RunScript = append(fakeCmd.RunScript, makeFakeOutput("", c.errorOutputs[i], c.runErrors[i]))
+			}
+			client := newTrivyClient("trivy", fakeExec, nil, logging.NewLogger()).(*trivyClient)
+			client.wait = func(context.Context, time.Duration) error { return nil }
+
+			err := client.Scan(context.Background(), "https://github.com/owner/repo.git", "token", filepathForTest(t), true)
+			if c.wantErr && err == nil {
+				t.Fatal("Scan() error = nil, want error")
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("Scan() error = %v", err)
+			}
+			if got := fakeExec.CommandCalls; got != c.wantAttempts {
+				t.Fatalf("Scan() attempts = %d, want %d", got, c.wantAttempts)
+			}
+			if c.wantRepoErr && !errors.Is(err, gittransport.ErrRepositoryNotFound) {
+				t.Fatalf("Scan() error = %v, want repository not found", err)
+			}
+		})
+	}
+}
+
+func filepathForTest(t *testing.T) string {
+	t.Helper()
+	f, err := os.CreateTemp("", "dependency-retry-*.json")
+	if err != nil {
+		t.Fatalf("CreateTemp() error = %v", err)
+	}
+	path := f.Name()
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	t.Cleanup(func() { os.Remove(path) })
+	return path
 }
 
 type ExecArgs struct {

--- a/pkg/dependency/dependency_test.go
+++ b/pkg/dependency/dependency_test.go
@@ -145,6 +145,7 @@ func TestScan(t *testing.T) {
 		scanResult     string
 		scanError      error
 		wantErrContain string
+		wantErrExclude string
 		want           []byte
 		wantErr        bool
 	}{
@@ -161,11 +162,12 @@ func TestScan(t *testing.T) {
 			name:           "NG scan error",
 			wantErr:        true,
 			wantErrContain: "something occurs",
+			wantErrExclude: "sensitive credential diagnostic",
 			cloneURL:       "test",
 			execScript: ExecArgs{
 				command:     "/usr/local/bin/trivy",
 				args:        []string{"repository", "--security-checks", "vuln", "--output", "path", "--format", "json", "url"},
-				errorOutput: "repository not found",
+				errorOutput: "sensitive credential diagnostic",
 				err:         errors.New("something occurs"),
 			},
 		},
@@ -195,6 +197,9 @@ func TestScan(t *testing.T) {
 			}
 			if c.wantErrContain != "" && (err == nil || !strings.Contains(err.Error(), c.wantErrContain)) {
 				t.Fatalf("error = %v, want it to contain %q", err, c.wantErrContain)
+			}
+			if c.wantErrExclude != "" && err != nil && strings.Contains(err.Error(), c.wantErrExclude) {
+				t.Fatalf("error = %v, want it not to contain %q", err, c.wantErrExclude)
 			}
 		})
 	}

--- a/pkg/dependency/dependency_test.go
+++ b/pkg/dependency/dependency_test.go
@@ -278,7 +278,7 @@ func TestScanGitHubAppRepositoryNotFoundRetry(t *testing.T) {
 	}
 }
 
-func TestScanRetryPreservesRepositoryNotFoundClassification(t *testing.T) {
+func TestScanRetryPreparationFailureIsNotRepositoryNotFound(t *testing.T) {
 	fakeExec := &fakeexec.FakeExec{}
 	fakeCmd := &fakeexec.FakeCmd{}
 	var stdout bytes.Buffer
@@ -292,8 +292,8 @@ func TestScanRetryPreservesRepositoryNotFoundClassification(t *testing.T) {
 	client.wait = func(context.Context, time.Duration) error { return context.Canceled }
 
 	err := client.Scan(context.Background(), "https://github.com/owner/repo.git", "token", filepathForTest(t), true)
-	if !errors.Is(err, gittransport.ErrRepositoryNotFound) {
-		t.Fatalf("Scan() error = %v, want repository not found classification", err)
+	if errors.Is(err, gittransport.ErrRepositoryNotFound) {
+		t.Fatalf("Scan() error = %v, do not want repository not found classification", err)
 	}
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Scan() error = %v, want context canceled", err)

--- a/pkg/dependency/handler.go
+++ b/pkg/dependency/handler.go
@@ -212,7 +212,7 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 			continue
 		}
 
-		if err := s.scanRepository(ctx, msg, gitHubSetting, beforeScanAt, r, token); err != nil {
+		if err := s.scanRepository(ctx, msg, gitHubSetting, beforeScanAt, r, token, receiveCount); err != nil {
 			return successfullyScannedRepos, err
 		}
 		successfullyScannedRepos = append(successfullyScannedRepos, repoFullName)
@@ -220,7 +220,7 @@ func (s *sqsHandler) scanAllRepositories(ctx context.Context, msg *message.CodeQ
 	return successfullyScannedRepos, nil
 }
 
-func (s *sqsHandler) scanRepository(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, beforeScanAt time.Time, r *github.Repository, token string) error {
+func (s *sqsHandler) scanRepository(ctx context.Context, msg *message.CodeQueueMessage, gitHubSetting *code.GitHubSetting, beforeScanAt time.Time, r *github.Repository, token string, receiveCount int) error {
 	repoFullName := r.GetFullName()
 	resultFile, err := os.CreateTemp("", "dependency-*.json")
 	if err != nil {
@@ -235,9 +235,13 @@ func (s *sqsHandler) scanRepository(ctx context.Context, msg *message.CodeQueueM
 	}
 	defer os.Remove(resultFilePath)
 
-	result, err := s.dependencyClient.getResult(ctx, *r.CloneURL, token, resultFilePath)
+	result, err := s.dependencyClient.getResult(ctx, *r.CloneURL, token, resultFilePath, gitHubSetting.AuthMode == code.GitHubAuthModeGitHubApp)
 	if err != nil {
 		s.logger.Errorf(ctx, "Failed to scan repositories: github_setting_id=%d, err=%+v", msg.GitHubSettingID, err)
+		if common.ShouldRetryGitHubAppRepositoryNotFound(gitHubSetting, err, receiveCount) {
+			s.updateRepositoryStatusRetryingWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName)
+			return err
+		}
 		s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
 		return mimosasqs.WrapNonRetryable(err)
 	}
@@ -312,6 +316,12 @@ func (s *sqsHandler) updateRepositoryStatusError(ctx context.Context, projectID,
 
 func (s *sqsHandler) updateRepositoryStatusInProgress(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName string) error {
 	return s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_IN_PROGRESS, "")
+}
+
+func (s *sqsHandler) updateRepositoryStatusRetryingWithWarn(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName string) {
+	if err := s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_IN_PROGRESS, common.GitHubAppRepositoryNotFoundRetryStatusDetail); err != nil {
+		s.logger.Warnf(ctx, "Failed to update repository status retrying: repository_name=%s, err=%+v", repositoryFullName, err)
+	}
 }
 
 func (s *sqsHandler) updateRepositoryStatusSuccess(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName string) error {

--- a/pkg/dependency/handler_test.go
+++ b/pkg/dependency/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ca-risken/code/pkg/common"
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/datasource-api/pkg/message"
 	"github.com/ca-risken/datasource-api/proto/code"
@@ -114,6 +115,35 @@ func TestUpdateRepositoryStatusInProgress(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("updateRepositoryStatusInProgress() error = %v, wantErr %v", err, tt.wantErr)
 			}
+			mockCode.AssertExpectations(t)
+		})
+	}
+}
+
+func TestUpdateRepositoryStatusRetrying(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "keeps retryable failure in progress"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCode := mocks.CodeServiceClient{}
+			mockCode.
+				On("PutDependencyRepository", mock.Anything, mock.MatchedBy(func(req *code.PutDependencyRepositoryRequest) bool {
+					return req.ProjectId == 1 &&
+						req.DependencyRepository.GithubSettingId == 2 &&
+						req.DependencyRepository.RepositoryFullName == "owner/repo" &&
+						req.DependencyRepository.Status == code.Status_IN_PROGRESS &&
+						req.DependencyRepository.StatusDetail == common.GitHubAppRepositoryNotFoundRetryStatusDetail &&
+						req.DependencyRepository.ScanAt > 0
+				})).
+				Return(&emptypb.Empty{}, nil).
+				Once()
+			s := sqsHandler{codeClient: &mockCode, logger: logging.NewLogger()}
+
+			s.updateRepositoryStatusRetryingWithWarn(context.Background(), 1, 2, "owner/repo")
+
 			mockCode.AssertExpectations(t)
 		})
 	}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -159,6 +159,22 @@ func prepareCloneDestination(dstDir string) error {
 	if err != nil || !filepath.IsAbs(cleanedDstDir) || relativePath == "." || relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(os.PathSeparator)) {
 		return fmt.Errorf("unsafe clone destination: %s", dstDir)
 	}
+	info, err := os.Lstat(cleanedDstDir)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("unsafe clone destination: %s", dstDir)
+	}
+	resolvedDstDir, err := filepath.EvalSymlinks(cleanedDstDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve clone destination %s: %w", dstDir, err)
+	}
+	resolvedTempDir, err := filepath.EvalSymlinks(tempDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve temporary directory %s: %w", tempDir, err)
+	}
+	resolvedRelativePath, err := filepath.Rel(resolvedTempDir, resolvedDstDir)
+	if err != nil || resolvedRelativePath == "." || resolvedRelativePath == ".." || strings.HasPrefix(resolvedRelativePath, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("unsafe resolved clone destination: %s", dstDir)
+	}
 	if err := os.RemoveAll(cleanedDstDir); err != nil {
 		return fmt.Errorf("failed to clean clone destination %s: %w", dstDir, err)
 	}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -114,39 +115,28 @@ func (g *riskenGitHubClient) Clone(ctx context.Context, token string, cloneURL s
 	if err == nil {
 		return nil
 	}
-	if retryRepositoryNotFound && errors.Is(err, gittransport.ErrRepositoryNotFound) {
-		return g.retryRepositoryNotFound(ctx, resolvedToken, cloneURL, dstDir, err)
-	}
-	return g.retryCloneWithExponentialBackOff(ctx, resolvedToken, cloneURL, dstDir, err, retryRepositoryNotFound)
+	return g.retryClone(ctx, resolvedToken, cloneURL, dstDir, err, retryRepositoryNotFound)
 }
 
-func (g *riskenGitHubClient) retryRepositoryNotFound(ctx context.Context, token, cloneURL, dstDir string, initialErr error) error {
-	err := initialErr
-	for _, interval := range gitHubAppRepositoryNotFoundRetryIntervals {
-		g.newRetryLogger(ctx, "github clone")(err, interval)
-		if waitErr := g.wait(ctx, interval); waitErr != nil {
-			return fmt.Errorf("failed to clone %s to %s: %w", cloneURL, dstDir, waitErr)
-		}
-		if prepareErr := prepareCloneDestination(dstDir); prepareErr != nil {
-			return prepareErr
-		}
-		err = g.clone(token, cloneURL, dstDir)
-		if err == nil {
-			return nil
-		}
-		if !errors.Is(err, gittransport.ErrRepositoryNotFound) {
-			return fmt.Errorf("failed to clone %s to %s: %w", cloneURL, dstDir, err)
-		}
-	}
-	return fmt.Errorf("failed to clone %s to %s: %w", cloneURL, dstDir, err)
-}
-
-func (g *riskenGitHubClient) retryCloneWithExponentialBackOff(ctx context.Context, token, cloneURL, dstDir string, initialErr error, retryRepositoryNotFound bool) error {
+func (g *riskenGitHubClient) retryClone(ctx context.Context, token, cloneURL, dstDir string, initialErr error, retryRepositoryNotFound bool) error {
 	err := initialErr
 	retryer := backoff.NewExponentialBackOff()
 	retryer.Reset()
+	repositoryNotFoundRetryIndex := 0
 	for range RETRY_NUM {
-		interval := retryer.NextBackOff()
+		var interval time.Duration
+		if retryRepositoryNotFound && errors.Is(err, gittransport.ErrRepositoryNotFound) {
+			if repositoryNotFoundRetryIndex >= len(gitHubAppRepositoryNotFoundRetryIntervals) {
+				break
+			}
+			interval = gitHubAppRepositoryNotFoundRetryIntervals[repositoryNotFoundRetryIndex]
+			repositoryNotFoundRetryIndex++
+		} else {
+			interval = retryer.NextBackOff()
+			if interval == backoff.Stop {
+				break
+			}
+		}
 		g.newRetryLogger(ctx, "github clone")(err, interval)
 		if waitErr := g.wait(ctx, interval); waitErr != nil {
 			return fmt.Errorf("failed to clone %s to %s: %w", cloneURL, dstDir, waitErr)
@@ -157,19 +147,22 @@ func (g *riskenGitHubClient) retryCloneWithExponentialBackOff(ctx context.Contex
 		err = g.clone(token, cloneURL, dstDir)
 		if err == nil {
 			return nil
-		}
-		if retryRepositoryNotFound && errors.Is(err, gittransport.ErrRepositoryNotFound) {
-			return g.retryRepositoryNotFound(ctx, token, cloneURL, dstDir, err)
 		}
 	}
 	return fmt.Errorf("failed to clone %s to %s: %w", cloneURL, dstDir, err)
 }
 
 func prepareCloneDestination(dstDir string) error {
-	if err := os.RemoveAll(dstDir); err != nil {
+	cleanedDstDir := filepath.Clean(dstDir)
+	tempDir := filepath.Clean(os.TempDir())
+	relativePath, err := filepath.Rel(tempDir, cleanedDstDir)
+	if err != nil || !filepath.IsAbs(cleanedDstDir) || relativePath == "." || relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("unsafe clone destination: %s", dstDir)
+	}
+	if err := os.RemoveAll(cleanedDstDir); err != nil {
 		return fmt.Errorf("failed to clean clone destination %s: %w", dstDir, err)
 	}
-	if err := os.MkdirAll(dstDir, 0700); err != nil {
+	if err := os.MkdirAll(cleanedDstDir, 0700); err != nil {
 		return fmt.Errorf("failed to recreate clone destination %s: %w", dstDir, err)
 	}
 	return nil

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -139,10 +139,10 @@ func (g *riskenGitHubClient) retryClone(ctx context.Context, token, cloneURL, ds
 		}
 		g.newRetryLogger(ctx, "github clone")(err, interval)
 		if waitErr := g.wait(ctx, interval); waitErr != nil {
-			return fmt.Errorf("failed to clone %s to %s: %w", cloneURL, dstDir, errors.Join(err, waitErr))
+			return fmt.Errorf("failed to wait before retrying clone %s: %w", cloneURL, waitErr)
 		}
 		if prepareErr := prepareCloneDestination(dstDir); prepareErr != nil {
-			return errors.Join(err, prepareErr)
+			return fmt.Errorf("failed to prepare clone destination %s: %w", dstDir, prepareErr)
 		}
 		err = g.clone(token, cloneURL, dstDir)
 		if err == nil {

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -139,10 +139,10 @@ func (g *riskenGitHubClient) retryClone(ctx context.Context, token, cloneURL, ds
 		}
 		g.newRetryLogger(ctx, "github clone")(err, interval)
 		if waitErr := g.wait(ctx, interval); waitErr != nil {
-			return fmt.Errorf("failed to clone %s to %s: %w", cloneURL, dstDir, waitErr)
+			return fmt.Errorf("failed to clone %s to %s: %w", cloneURL, dstDir, errors.Join(err, waitErr))
 		}
 		if prepareErr := prepareCloneDestination(dstDir); prepareErr != nil {
-			return prepareErr
+			return errors.Join(err, prepareErr)
 		}
 		err = g.clone(token, cloneURL, dstDir)
 		if err == nil {

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -12,8 +13,15 @@ import (
 	"github.com/ca-risken/datasource-api/proto/code"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/go-git/go-git/v5"
+	gittransport "github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
+
+var gitHubAppRepositoryNotFoundRetryIntervals = []time.Duration{
+	3 * time.Second,
+	10 * time.Second,
+	30 * time.Second,
+}
 
 const RETRY_NUM uint64 = 3
 
@@ -25,23 +33,29 @@ type GithubServiceClient interface {
 }
 
 type AppAuthConfig = githubappauth.Config
+type retryRepositoryNotFoundContextKey struct{}
+
+func WithRepositoryNotFoundRetry(ctx context.Context) context.Context {
+	return context.WithValue(ctx, retryRepositoryNotFoundContextKey{}, true)
+}
 
 type riskenGitHubClient struct {
 	defaultToken string
 	appAuth      *githubappauth.Client
-	retryer      backoff.BackOff
 	logger       logging.Logger
+	clone        func(token, cloneURL, dstDir string) error
+	wait         func(context.Context, time.Duration) error
 }
 
 func NewGithubClient(defaultToken string, logger logging.Logger) *riskenGitHubClient {
 	client, err := NewGithubClientWithAppAuth(defaultToken, nil, logger)
 	if err != nil {
 		logger.Warnf(context.Background(), "failed to initialize GitHub App auth; using PAT-only client: %+v", err)
-		retry := RETRY_NUM
 		return &riskenGitHubClient{
 			defaultToken: defaultToken,
-			retryer:      backoff.WithMaxRetries(backoff.NewExponentialBackOff(), retry),
 			logger:       logger,
+			clone:        cloneRepository,
+			wait:         waitForRetry,
 		}
 	}
 	return client
@@ -55,12 +69,12 @@ func NewGithubClientWithAppAuth(defaultToken string, appAuthCfg *AppAuthConfig, 
 	if !appAuth.Enabled() {
 		appAuth = nil
 	}
-	retry := RETRY_NUM
 	return &riskenGitHubClient{
 		defaultToken: defaultToken,
 		appAuth:      appAuth,
-		retryer:      backoff.WithMaxRetries(backoff.NewExponentialBackOff(), retry),
 		logger:       logger,
+		clone:        cloneRepository,
+		wait:         waitForRetry,
 	}, nil
 }
 
@@ -71,22 +85,93 @@ func getToken(token, defaultToken string) string {
 	return defaultToken
 }
 
+func cloneRepository(token, cloneURL, dstDir string) error {
+	_, err := git.PlainClone(dstDir, false, &git.CloneOptions{
+		URL: cloneURL,
+		Auth: &http.BasicAuth{
+			Username: "dummy", // anything except an empty string
+			Password: token,
+		},
+	})
+	return err
+}
+
+func waitForRetry(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 func (g *riskenGitHubClient) Clone(ctx context.Context, token string, cloneURL string, dstDir string) error {
-	operation := func() error {
-		_, err := git.PlainClone(dstDir, false, &git.CloneOptions{
-			URL: cloneURL,
-			Auth: &http.BasicAuth{
-				Username: "dummy", // anything except an empty string
-				Password: getToken(token, g.defaultToken),
-			},
-		})
-		return err
+	retryRepositoryNotFound, _ := ctx.Value(retryRepositoryNotFoundContextKey{}).(bool)
+	resolvedToken := getToken(token, g.defaultToken)
+	err := g.clone(resolvedToken, cloneURL, dstDir)
+	if err == nil {
+		return nil
 	}
-
-	if err := backoff.RetryNotify(operation, g.retryer, g.newRetryLogger(ctx, "github clone")); err != nil {
-		return fmt.Errorf("failed to clone %s to %s: %w", cloneURL, dstDir, err)
+	if retryRepositoryNotFound && errors.Is(err, gittransport.ErrRepositoryNotFound) {
+		return g.retryRepositoryNotFound(ctx, resolvedToken, cloneURL, dstDir, err)
 	}
+	return g.retryCloneWithExponentialBackOff(ctx, resolvedToken, cloneURL, dstDir, err, retryRepositoryNotFound)
+}
 
+func (g *riskenGitHubClient) retryRepositoryNotFound(ctx context.Context, token, cloneURL, dstDir string, initialErr error) error {
+	err := initialErr
+	for _, interval := range gitHubAppRepositoryNotFoundRetryIntervals {
+		g.newRetryLogger(ctx, "github clone")(err, interval)
+		if waitErr := g.wait(ctx, interval); waitErr != nil {
+			return fmt.Errorf("failed to clone %s to %s: %w", cloneURL, dstDir, waitErr)
+		}
+		if prepareErr := prepareCloneDestination(dstDir); prepareErr != nil {
+			return prepareErr
+		}
+		err = g.clone(token, cloneURL, dstDir)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, gittransport.ErrRepositoryNotFound) {
+			return fmt.Errorf("failed to clone %s to %s: %w", cloneURL, dstDir, err)
+		}
+	}
+	return fmt.Errorf("failed to clone %s to %s: %w", cloneURL, dstDir, err)
+}
+
+func (g *riskenGitHubClient) retryCloneWithExponentialBackOff(ctx context.Context, token, cloneURL, dstDir string, initialErr error, retryRepositoryNotFound bool) error {
+	err := initialErr
+	retryer := backoff.NewExponentialBackOff()
+	retryer.Reset()
+	for range RETRY_NUM {
+		interval := retryer.NextBackOff()
+		g.newRetryLogger(ctx, "github clone")(err, interval)
+		if waitErr := g.wait(ctx, interval); waitErr != nil {
+			return fmt.Errorf("failed to clone %s to %s: %w", cloneURL, dstDir, waitErr)
+		}
+		if prepareErr := prepareCloneDestination(dstDir); prepareErr != nil {
+			return prepareErr
+		}
+		err = g.clone(token, cloneURL, dstDir)
+		if err == nil {
+			return nil
+		}
+		if retryRepositoryNotFound && errors.Is(err, gittransport.ErrRepositoryNotFound) {
+			return g.retryRepositoryNotFound(ctx, token, cloneURL, dstDir, err)
+		}
+	}
+	return fmt.Errorf("failed to clone %s to %s: %w", cloneURL, dstDir, err)
+}
+
+func prepareCloneDestination(dstDir string) error {
+	if err := os.RemoveAll(dstDir); err != nil {
+		return fmt.Errorf("failed to clean clone destination %s: %w", dstDir, err)
+	}
+	if err := os.MkdirAll(dstDir, 0700); err != nil {
+		return fmt.Errorf("failed to recreate clone destination %s: %w", dstDir, err)
+	}
 	return nil
 }
 

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -6,10 +6,17 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/datasource-api/proto/code"
+	gittransport "github.com/go-git/go-git/v5/plumbing/transport"
 )
 
 func generateRSAPrivateKeyPEM(t *testing.T) string {
@@ -198,5 +205,125 @@ func TestResolveAccessTokenGitHubAppRequiresAppAuth(t *testing.T) {
 	}
 	if err.Error() != "github app auth is not configured" {
 		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestCloneRetryPolicy(t *testing.T) {
+	cases := []struct {
+		name        string
+		ctx         context.Context
+		cloneErr    error
+		wantAttempt int32
+	}{
+		{
+			name:        "GitHub App repository not found retries independently",
+			ctx:         WithRepositoryNotFoundRetry(context.Background()),
+			cloneErr:    gittransport.ErrRepositoryNotFound,
+			wantAttempt: 4,
+		},
+		{
+			name:        "repository not found without GitHub App retry",
+			ctx:         context.Background(),
+			cloneErr:    gittransport.ErrRepositoryNotFound,
+			wantAttempt: 4,
+		},
+		{
+			name:        "non retryable error",
+			ctx:         WithRepositoryNotFoundRetry(context.Background()),
+			cloneErr:    errors.New("permanent"),
+			wantAttempt: 4,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var attempts atomic.Int32
+			client := &riskenGitHubClient{
+				logger: logging.NewLogger(),
+				clone: func(token, cloneURL, dstDir string) error {
+					attempts.Add(1)
+					return c.cloneErr
+				},
+				wait: func(context.Context, time.Duration) error { return nil },
+			}
+			dir := t.TempDir()
+
+			err := client.Clone(c.ctx, "token", "https://github.com/owner/repo.git", dir)
+			if err == nil {
+				t.Fatal("Clone() error = nil, want error")
+			}
+			if got := attempts.Load(); got != c.wantAttempt {
+				t.Fatalf("Clone() attempts = %d, want %d", got, c.wantAttempt)
+			}
+		})
+	}
+}
+
+func TestCloneRetryIsolationUnderConcurrency(t *testing.T) {
+	const concurrentCalls = 10
+	var attempts atomic.Int32
+	client := &riskenGitHubClient{
+		logger: logging.NewLogger(),
+		clone: func(token, cloneURL, dstDir string) error {
+			attempts.Add(1)
+			return gittransport.ErrRepositoryNotFound
+		},
+		wait: func(context.Context, time.Duration) error { return nil },
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(concurrentCalls)
+	for range concurrentCalls {
+		go func() {
+			defer wg.Done()
+			err := client.Clone(
+				WithRepositoryNotFoundRetry(context.Background()),
+				"token",
+				"https://github.com/owner/repo.git",
+				t.TempDir(),
+			)
+			if err == nil {
+				t.Errorf("Clone() error = nil, want error")
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got, want := attempts.Load(), int32(concurrentCalls*(len(gitHubAppRepositoryNotFoundRetryIntervals)+1)); got != want {
+		t.Fatalf("Clone() total attempts = %d, want %d", got, want)
+	}
+}
+
+func TestCloneCleansDestinationBeforeRetry(t *testing.T) {
+	var attempts int
+	client := &riskenGitHubClient{
+		logger: logging.NewLogger(),
+		clone: func(token, cloneURL, dstDir string) error {
+			attempts++
+			partialPath := filepath.Join(dstDir, "partial")
+			if attempts == 1 {
+				if err := os.WriteFile(partialPath, []byte("partial"), 0600); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+				return gittransport.ErrRepositoryNotFound
+			}
+			if _, err := os.Stat(partialPath); !os.IsNotExist(err) {
+				t.Fatalf("partial clone data remains before retry: err=%v", err)
+			}
+			return nil
+		},
+		wait: func(context.Context, time.Duration) error { return nil },
+	}
+
+	if err := client.Clone(
+		WithRepositoryNotFoundRetry(context.Background()),
+		"token",
+		"https://github.com/owner/repo.git",
+		t.TempDir(),
+	); err != nil {
+		t.Fatalf("Clone() error = %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("Clone() attempts = %d, want 2", attempts)
 	}
 }

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -364,17 +364,44 @@ func TestCloneRetryIsolationUnderConcurrency(t *testing.T) {
 func TestPrepareCloneDestinationRejectsUnsafePaths(t *testing.T) {
 	cases := []struct {
 		name string
-		path string
+		path func(*testing.T) string
 	}{
-		{name: "empty", path: ""},
-		{name: "relative", path: "relative/path"},
-		{name: "temporary directory root", path: os.TempDir()},
+		{name: "empty", path: func(*testing.T) string { return "" }},
+		{name: "relative", path: func(*testing.T) string { return "relative/path" }},
+		{name: "temporary directory root", path: func(*testing.T) string { return os.TempDir() }},
+		{
+			name: "regular file",
+			path: func(t *testing.T) string {
+				file, err := os.CreateTemp("", "clone-destination-file-*")
+				if err != nil {
+					t.Fatalf("CreateTemp() error = %v", err)
+				}
+				if err := file.Close(); err != nil {
+					t.Fatalf("Close() error = %v", err)
+				}
+				t.Cleanup(func() { os.Remove(file.Name()) })
+				return file.Name()
+			},
+		},
+		{
+			name: "symbolic link",
+			path: func(t *testing.T) string {
+				target := t.TempDir()
+				link := filepath.Join(os.TempDir(), "clone-destination-link-"+filepath.Base(target))
+				if err := os.Symlink(target, link); err != nil {
+					t.Fatalf("Symlink() error = %v", err)
+				}
+				t.Cleanup(func() { os.Remove(link) })
+				return link
+			},
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if err := prepareCloneDestination(c.path); err == nil {
-				t.Fatalf("prepareCloneDestination(%q) error = nil, want error", c.path)
+			path := c.path(t)
+			if err := prepareCloneDestination(path); err == nil {
+				t.Fatalf("prepareCloneDestination(%q) error = nil, want error", path)
 			}
 		})
 	}

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -259,6 +260,72 @@ func TestCloneRetryPolicy(t *testing.T) {
 	}
 }
 
+func TestCloneRetryPolicyTransitions(t *testing.T) {
+	cases := []struct {
+		name      string
+		cloneErrs []error
+		wantErr   error
+		wantWaits []time.Duration
+	}{
+		{
+			name:      "generic error changes to repository not found without resetting retry budget",
+			cloneErrs: []error{errors.New("temporary"), gittransport.ErrRepositoryNotFound, gittransport.ErrRepositoryNotFound, gittransport.ErrRepositoryNotFound},
+			wantErr:   gittransport.ErrRepositoryNotFound,
+			wantWaits: []time.Duration{0, 3 * time.Second, 10 * time.Second},
+		},
+		{
+			name:      "repository not found changes to generic error without resetting retry budget",
+			cloneErrs: []error{gittransport.ErrRepositoryNotFound, errors.New("temporary"), errors.New("temporary"), errors.New("permanent")},
+			wantErr:   errors.New("permanent"),
+			wantWaits: []time.Duration{3 * time.Second, 0, 0},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var attempts int
+			var waits []time.Duration
+			client := &riskenGitHubClient{
+				logger: logging.NewLogger(),
+				clone: func(token, cloneURL, dstDir string) error {
+					err := c.cloneErrs[attempts]
+					attempts++
+					return err
+				},
+				wait: func(_ context.Context, interval time.Duration) error {
+					waits = append(waits, interval)
+					return nil
+				},
+			}
+
+			err := client.Clone(WithRepositoryNotFoundRetry(context.Background()), "token", "https://github.com/owner/repo.git", t.TempDir())
+			if err == nil {
+				t.Fatal("Clone() error = nil, want error")
+			}
+			if attempts != len(c.cloneErrs) {
+				t.Fatalf("Clone() attempts = %d, want %d", attempts, len(c.cloneErrs))
+			}
+			if !errors.Is(err, c.wantErr) && !strings.Contains(err.Error(), c.wantErr.Error()) {
+				t.Fatalf("Clone() error = %v, want %v", err, c.wantErr)
+			}
+			if len(waits) != len(c.wantWaits) {
+				t.Fatalf("Clone() waits = %v, want %v", waits, c.wantWaits)
+			}
+			for i, wantWait := range c.wantWaits {
+				if wantWait == 0 {
+					if waits[i] == 3*time.Second || waits[i] == 10*time.Second || waits[i] == 30*time.Second {
+						t.Fatalf("Clone() wait[%d] = %v, want short exponential backoff", i, waits[i])
+					}
+					continue
+				}
+				if waits[i] != wantWait {
+					t.Fatalf("Clone() wait[%d] = %v, want %v", i, waits[i], wantWait)
+				}
+			}
+		})
+	}
+}
+
 func TestCloneRetryIsolationUnderConcurrency(t *testing.T) {
 	const concurrentCalls = 10
 	var attempts atomic.Int32
@@ -291,6 +358,25 @@ func TestCloneRetryIsolationUnderConcurrency(t *testing.T) {
 
 	if got, want := attempts.Load(), int32(concurrentCalls*(len(gitHubAppRepositoryNotFoundRetryIntervals)+1)); got != want {
 		t.Fatalf("Clone() total attempts = %d, want %d", got, want)
+	}
+}
+
+func TestPrepareCloneDestinationRejectsUnsafePaths(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{name: "empty", path: ""},
+		{name: "relative", path: "relative/path"},
+		{name: "temporary directory root", path: os.TempDir()},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := prepareCloneDestination(c.path); err == nil {
+				t.Fatalf("prepareCloneDestination(%q) error = nil, want error", c.path)
+			}
+		})
 	}
 }
 

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -380,6 +380,42 @@ func TestPrepareCloneDestinationRejectsUnsafePaths(t *testing.T) {
 	}
 }
 
+func TestCloneRetryPreservesRepositoryNotFoundClassification(t *testing.T) {
+	cases := []struct {
+		name    string
+		dstDir  func(*testing.T) string
+		waitErr error
+	}{
+		{
+			name:    "wait failure",
+			dstDir:  func(t *testing.T) string { return t.TempDir() },
+			waitErr: context.Canceled,
+		},
+		{
+			name:   "destination reset failure",
+			dstDir: func(*testing.T) string { return "relative/path" },
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			client := &riskenGitHubClient{
+				logger: logging.NewLogger(),
+				clone:  func(token, cloneURL, dstDir string) error { return gittransport.ErrRepositoryNotFound },
+				wait:   func(context.Context, time.Duration) error { return c.waitErr },
+			}
+
+			err := client.Clone(WithRepositoryNotFoundRetry(context.Background()), "token", "https://github.com/owner/repo.git", c.dstDir(t))
+			if !errors.Is(err, gittransport.ErrRepositoryNotFound) {
+				t.Fatalf("Clone() error = %v, want repository not found classification", err)
+			}
+			if c.waitErr != nil && !errors.Is(err, c.waitErr) {
+				t.Fatalf("Clone() error = %v, want %v", err, c.waitErr)
+			}
+		})
+	}
+}
+
 func TestCloneCleansDestinationBeforeRetry(t *testing.T) {
 	var attempts int
 	client := &riskenGitHubClient{

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -407,7 +407,7 @@ func TestPrepareCloneDestinationRejectsUnsafePaths(t *testing.T) {
 	}
 }
 
-func TestCloneRetryPreservesRepositoryNotFoundClassification(t *testing.T) {
+func TestCloneRetryPreparationFailureIsNotRepositoryNotFound(t *testing.T) {
 	cases := []struct {
 		name    string
 		dstDir  func(*testing.T) string
@@ -433,8 +433,8 @@ func TestCloneRetryPreservesRepositoryNotFoundClassification(t *testing.T) {
 			}
 
 			err := client.Clone(WithRepositoryNotFoundRetry(context.Background()), "token", "https://github.com/owner/repo.git", c.dstDir(t))
-			if !errors.Is(err, gittransport.ErrRepositoryNotFound) {
-				t.Fatalf("Clone() error = %v, want repository not found classification", err)
+			if errors.Is(err, gittransport.ErrRepositoryNotFound) {
+				t.Fatalf("Clone() error = %v, do not want repository not found classification", err)
 			}
 			if c.waitErr != nil && !errors.Is(err, c.waitErr) {
 				t.Fatalf("Clone() error = %v, want %v", err, c.waitErr)

--- a/pkg/gitleaks/handler.go
+++ b/pkg/gitleaks/handler.go
@@ -186,6 +186,12 @@ func (s *sqsHandler) updateRepositoryStatusInProgress(ctx context.Context, proje
 	return s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_IN_PROGRESS, "")
 }
 
+func (s *sqsHandler) updateRepositoryStatusRetryingWithWarn(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName string) {
+	if err := s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_IN_PROGRESS, common.GitHubAppRepositoryNotFoundRetryStatusDetail); err != nil {
+		s.logger.Warnf(ctx, "Failed to update repository status retrying: repository_name=%s, err=%+v", repositoryFullName, err)
+	}
+}
+
 func (s *sqsHandler) updateRepositoryStatusError(ctx context.Context, projectID, githubSettingID uint32, repositoryFullName, statusDetail string) error {
 	return s.updateRepositoryStatus(ctx, projectID, githubSettingID, repositoryFullName, code.Status_ERROR, statusDetail)
 }
@@ -288,13 +294,18 @@ func (s *sqsHandler) scanDiffRepositories(ctx context.Context, msg *message.Code
 		}
 
 		// Scan per repository
-		results, scanAt, err := s.scanRepository(ctx, r, token, lastScannedAt, msg)
+		scanCtx := ctx
+		if gitHubSetting.AuthMode == code.GitHubAuthModeGitHubApp {
+			scanCtx = githubcli.WithRepositoryNotFoundRetry(ctx)
+		}
+		results, scanAt, err := s.scanRepository(scanCtx, r, token, lastScannedAt, msg)
 		if err != nil {
 			s.logger.Errorf(ctx, "Failed to scan repositories: github_setting_id=%d, repository_full_name=%s, err=%+v", msg.GitHubSettingID, repoFullName, err)
-			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
 			if common.ShouldRetryGitHubAppRepositoryNotFound(gitHubSetting, err, receiveCount) {
+				s.updateRepositoryStatusRetryingWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName)
 				return err
 			}
+			s.updateRepositoryStatusErrorWithWarn(ctx, msg.ProjectID, msg.GitHubSettingID, repoFullName, err.Error())
 			return mimosasqs.WrapNonRetryable(err)
 		}
 

--- a/pkg/gitleaks/handler_test.go
+++ b/pkg/gitleaks/handler_test.go
@@ -79,6 +79,35 @@ func TestGetRepositoriesFromCodeQueueMessage(t *testing.T) {
 	}
 }
 
+func TestUpdateRepositoryStatusRetrying(t *testing.T) {
+	cases := []struct {
+		name string
+	}{
+		{name: "keeps retryable failure in progress"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mockCode := mocks.CodeServiceClient{}
+			mockCode.
+				On("PutGitleaksRepository", mock.Anything, mock.MatchedBy(func(req *code.PutGitleaksRepositoryRequest) bool {
+					return req.ProjectId == 1 &&
+						req.GitleaksRepository.GithubSettingId == 2 &&
+						req.GitleaksRepository.RepositoryFullName == "owner/repo" &&
+						req.GitleaksRepository.Status == code.Status_IN_PROGRESS &&
+						req.GitleaksRepository.StatusDetail == common.GitHubAppRepositoryNotFoundRetryStatusDetail &&
+						req.GitleaksRepository.ScanAt > 0
+				})).
+				Return(&emptypb.Empty{}, nil).
+				Once()
+			s := sqsHandler{codeClient: &mockCode, logger: logging.NewLogger()}
+
+			s.updateRepositoryStatusRetryingWithWarn(context.Background(), 1, 2, "owner/repo")
+
+			mockCode.AssertExpectations(t)
+		})
+	}
+}
+
 func TestValidateRepository(t *testing.T) {
 	now := time.Now()
 	tests := []struct {


### PR DESCRIPTION
## PRの概要

複数リポジトリを並行スキャンすると、cloneおよびTrivyのリトライ回数がクライアント全体で共有され、別リポジトリの失敗によって再試行枠が消費されていました。

GitHub AppのInstallation Tokenは、発行直後にGitHubのedge cacheへの反映が完了しておらず、private repositoryへのアクセスが一時的に`404 Repository Not Found`となる既知の挙動があります。

GitHub Supportは、tokenが各edge cacheへ複製されるまで時間がかかることを説明し、発行後に数秒待ったうえで、3秒、10秒、必要に応じて30秒後に再試行することを推奨しています（[AWS Amplify issue #4080](https://github.com/aws-amplify/amplify-hosting/issues/4080)）。

同様の断続的なclone 404はKargoでも報告されており、GitHub App認証を使ったprivate repositoryのcloneで成功と失敗が確率的に発生しています（[Kargo issue #5610](https://github.com/akuity/kargo/issues/5610)、[修正PR #6630](https://github.com/akuity/kargo/pull/6630)）。

RISKENでは、このGitHub側の一時的な事象を呼び出し単位の独立したリトライで吸収できず、子リポジトリをERRORとして確定してしまうことが問題でした。

スキャン対象はGitHub Appから取得したアクセス可能なリポジトリ一覧に限定され、Installation Tokenもリポジトリ単位で発行されます。この2段階のガードにより恒久的なRepository Not Foundは通常スキャン前に除外されるため、DependencyではTrivyのstderrを厳密な行単位で判定し、追加の認証付き`git ls-remote`は実行しません。誤判定が発生しても再試行回数は制限され、最終的にはERRORへ収束します。

この変更ではリトライ状態を処理単位に分離し、GitHub Appの一過性なRepository Not Foundに限って3秒、10秒、30秒の間隔で再試行します。

再試行可能な間は子リポジトリをERRORにせず、IN_PROGRESSと再試行中の理由を表示します。

| 状況 | 変更前 | 変更後 |
| --- | --- | --- |
| 複数リポジトリの並行実行 | リトライ回数を共有 | 各clone・Trivy処理が独立した回数を保持 |
| GitHub Appの一過性404 | 短い再試行で吸収できない場合がある | 3秒、10秒、30秒で限定的に再試行 |
| SQS再配信を待つ間 | 一時的にERRORを表示 | IN_PROGRESSと再試行理由を表示 |
| 再試行上限到達 | ERROR | ERROR |

```mermaid
flowchart LR
    A["スキャン開始"] --> B["clone / Trivy実行"]
    B -->|成功| C["OK"]
    B -->|GitHub Appの一過性404| D["呼び出し単位で再試行"]
    D -->|SQS再配信あり| E["IN_PROGRESSを維持"]
    D -->|回復| C
    D -->|上限到達| F["ERROR"]
```

通常のclone・Trivyエラーについては、従来相当の短い再試行を呼び出し単位で維持します。

## レビュー観点例

- [ ] 並行処理間でBackOffの状態を共有しない点。
- [ ] GitHub AppのRepository Not Foundだけを長い再試行の対象とする点。
- [ ] 再試行前にclone先ディレクトリとTrivy出力を初期化する点。
- [ ] SQS再配信対象ではIN_PROGRESSを維持し、上限到達時だけERRORにする点。
- [ ] 通常エラーに対する従来の短い再試行を維持する点。


